### PR TITLE
fix(renderer): widen batch indices to u32 (RC5 — fixes silent >65535-vertex overflow)

### DIFF
--- a/src/esengine/renderer/DrawList.cpp
+++ b/src/esengine/renderer/DrawList.cpp
@@ -103,8 +103,8 @@ void DrawList::execute(GfxDevice& device, StateTracker& state, TransientBufferPo
 
             device.drawElements(
                 cmd.index_count,
-                GfxDataType::UnsignedShort,
-                static_cast<u32>(static_cast<uintptr_t>(cmd.index_offset) * sizeof(u16)));
+                GfxDataType::UnsignedInt,
+                static_cast<u32>(static_cast<uintptr_t>(cmd.index_offset) * sizeof(u32)));
         }
 
         if (capture && capture->isCapturing()) {

--- a/src/esengine/renderer/RenderFrameSubmit.cpp
+++ b/src/esengine/renderer/RenderFrameSubmit.cpp
@@ -31,9 +31,9 @@ void RenderFrame::submitTileQuad(
     u32 vOff = pool_.appendVertices(LayoutId::Batch, verts, sizeof(verts));
     u32 baseVertex = vOff / sizeof(BatchVertex);
 
-    u16 indices[6];
+    u32 indices[6];
     for (u32 i = 0; i < 6; ++i) {
-        indices[i] = static_cast<u16>(baseVertex + TILE_QUAD_IDX[i]);
+        indices[i] = static_cast<u32>(baseVertex + TILE_QUAD_IDX[i]);
     }
     u32 iOff = pool_.appendIndices(LayoutId::Batch, indices, 6);
 

--- a/src/esengine/renderer/TransientBufferPool.cpp
+++ b/src/esengine/renderer/TransientBufferPool.cpp
@@ -80,8 +80,8 @@ void TransientBufferPool::writeVertices(LayoutId layout, u32 byteOffset, const v
     std::memcpy(stream(layout).vertex_staging.data() + byteOffset, data, byteSize);
 }
 
-void TransientBufferPool::writeIndices(LayoutId layout, u32 indexOffset, const u16* data, u32 count) {
-    std::memcpy(stream(layout).index_staging.data() + indexOffset, data, count * sizeof(u16));
+void TransientBufferPool::writeIndices(LayoutId layout, u32 indexOffset, const u32* data, u32 count) {
+    std::memcpy(stream(layout).index_staging.data() + indexOffset, data, count * sizeof(u32));
 }
 
 u32 TransientBufferPool::appendVertices(LayoutId layout, const void* data, u32 byteSize) {
@@ -90,7 +90,7 @@ u32 TransientBufferPool::appendVertices(LayoutId layout, const void* data, u32 b
     return offset;
 }
 
-u32 TransientBufferPool::appendIndices(LayoutId layout, const u16* data, u32 count) {
+u32 TransientBufferPool::appendIndices(LayoutId layout, const u32* data, u32 count) {
     u32 offset = allocIndices(layout, count);
     writeIndices(layout, offset, data, count);
     return offset;
@@ -110,12 +110,12 @@ void TransientBufferPool::upload() {
         }
 
         device_.bindIndexBuffer(s.ebo);
-        u32 eboBytes = s.index_write_pos * sizeof(u16);
-        u32 eboCapBytes = s.ebo_capacity * sizeof(u16);
+        u32 eboBytes = s.index_write_pos * sizeof(u32);
+        u32 eboCapBytes = s.ebo_capacity * sizeof(u32);
         if (eboBytes > eboCapBytes) {
             s.ebo_capacity = s.index_write_pos;
             device_.bufferData(GfxBufferTarget::Index, s.index_staging.data(),
-                                s.ebo_capacity * sizeof(u16), true);
+                                s.ebo_capacity * sizeof(u32), true);
         } else if (eboBytes > 0) {
             device_.bufferSubData(GfxBufferTarget::Index, 0, s.index_staging.data(), eboBytes);
         }
@@ -162,7 +162,7 @@ void TransientBufferPool::setupStream(LayoutId layout) {
     device_.bufferData(GfxBufferTarget::Vertex, nullptr, s.vbo_capacity, true);
 
     device_.bindIndexBuffer(s.ebo);
-    device_.bufferData(GfxBufferTarget::Index, nullptr, s.ebo_capacity * sizeof(u16), true);
+    device_.bufferData(GfxBufferTarget::Index, nullptr, s.ebo_capacity * sizeof(u32), true);
 
     s.vao = device_.createVertexArray();
     device_.bindVertexArray(s.vao);

--- a/src/esengine/renderer/TransientBufferPool.hpp
+++ b/src/esengine/renderer/TransientBufferPool.hpp
@@ -41,10 +41,10 @@ public:
     u32 allocIndices(LayoutId layout, u32 count);
 
     void writeVertices(LayoutId layout, u32 byteOffset, const void* data, u32 byteSize);
-    void writeIndices(LayoutId layout, u32 indexOffset, const u16* data, u32 count);
+    void writeIndices(LayoutId layout, u32 indexOffset, const u32* data, u32 count);
 
     u32 appendVertices(LayoutId layout, const void* data, u32 byteSize);
-    u32 appendIndices(LayoutId layout, const u16* data, u32 count);
+    u32 appendIndices(LayoutId layout, const u32* data, u32 count);
 
     /** Upload every non-empty stream's staging to its VBO/EBO. */
     void upload();
@@ -66,7 +66,7 @@ private:
         u32 ebo = 0;
         u32 vao = 0;
         std::vector<u8> vertex_staging;
-        std::vector<u16> index_staging;
+        std::vector<u32> index_staging;  // 32-bit indices: a single Batch stream can exceed 65535 vertices
         u32 vertex_write_pos = 0;
         u32 index_write_pos = 0;
         u32 vbo_capacity = 0;

--- a/src/esengine/renderer/plugins/ParticlePlugin.cpp
+++ b/src/esengine/renderer/plugins/ParticlePlugin.cpp
@@ -11,7 +11,7 @@
 
 namespace esengine {
 
-static constexpr u16 QUAD_INDICES[6] = { 0, 1, 2, 0, 2, 3 };
+static constexpr u32 QUAD_INDICES[6] = { 0, 1, 2, 0, 2, 3 };
 
 void ParticlePlugin::init(RenderFrameContext& ctx) {
     batch_shader_id_ = ctx.batch_shader_id;
@@ -76,7 +76,7 @@ void ParticlePlugin::collect(RenderCollectContext& collect_ctx) {
         u32 idxOffset = buffers.allocIndices(LayoutId::Batch, idxCount);
 
         auto* verts = reinterpret_cast<BatchVertex*>(buffers.vertexData(LayoutId::Batch) + vertByteOffset);
-        u16 baseVertex = static_cast<u16>(vertByteOffset / sizeof(BatchVertex));
+        u32 baseVertex = static_cast<u32>(vertByteOffset / sizeof(BatchVertex));
 
         u32 pi = 0;
         state->pool.forEachAlive([&](const particle::Particle& p) {
@@ -137,9 +137,9 @@ void ParticlePlugin::collect(RenderCollectContext& collect_ctx) {
             verts[vi + 3].texCoord = { u0, v0 };
 
             u32 ii = pi * 6;
-            u16 bv = baseVertex + static_cast<u16>(vi);
+            u32 bv = baseVertex + static_cast<u32>(vi);
             // Patch base vertex into indices
-            u16 patched[6];
+            u32 patched[6];
             for (u32 q = 0; q < 6; ++q) {
                 patched[q] = bv + QUAD_INDICES[q];
             }

--- a/src/esengine/renderer/plugins/ShapePlugin.cpp
+++ b/src/esengine/renderer/plugins/ShapePlugin.cpp
@@ -93,9 +93,9 @@ void ShapePlugin::collect(RenderCollectContext& collect_ctx) {
         u32 vOff = buffers.appendVertices(LayoutId::Shape, verts, sizeof(verts));
         u32 baseVertex = vOff / sizeof(ShapeVertex);
 
-        u16 indices[6];
+        u32 indices[6];
         for (u32 i = 0; i < 6; ++i) {
-            indices[i] = static_cast<u16>(baseVertex + QUAD_INDICES[i]);
+            indices[i] = static_cast<u32>(baseVertex + QUAD_INDICES[i]);
         }
         u32 iOff = buffers.appendIndices(LayoutId::Shape, indices, 6);
 
@@ -138,8 +138,8 @@ void ShapePlugin::customDraw(
 
     state.device().drawElements(
         cmd.index_count,
-        GfxDataType::UnsignedShort,
-        static_cast<u32>(cmd.index_offset * sizeof(u16)));
+        GfxDataType::UnsignedInt,
+        static_cast<u32>(cmd.index_offset * sizeof(u32)));
 }
 
 }  // namespace esengine

--- a/src/esengine/renderer/plugins/ShapePlugin.hpp
+++ b/src/esengine/renderer/plugins/ShapePlugin.hpp
@@ -28,7 +28,7 @@ private:
         f32 shapeType, halfW, halfH, cornerRadius;
     };
 
-    static constexpr u16 QUAD_INDICES[6] = { 0, 1, 2, 2, 3, 0 };
+    static constexpr u32 QUAD_INDICES[6] = { 0, 1, 2, 2, 3, 0 };
 
     resource::ShaderHandle shape_shader_handle_;
     u32 shape_shader_id_ = 0;

--- a/src/esengine/renderer/plugins/SpinePlugin.cpp
+++ b/src/esengine/renderer/plugins/SpinePlugin.cpp
@@ -61,7 +61,7 @@ void SpinePlugin::emitBatch(
     u32 baseVertex = vOff / sizeof(BatchVertex);
 
     for (auto& idx : indices_) {
-        idx = static_cast<u16>(idx + baseVertex);
+        idx = static_cast<u32>(idx + baseVertex);
     }
     u32 iOff = buffers.appendIndices(LayoutId::Batch, indices_.data(), static_cast<u32>(indices_.size()));
 
@@ -118,7 +118,7 @@ void SpinePlugin::emitRegionAttachment(
     f32 a = skelColor.a * slotColor.a * attachColor.a * tintColor.a;
     u32 pc = packColor(r, g, b, a);
 
-    u16 base = static_cast<u16>(vertices_.size());
+    u32 base = static_cast<u32>(vertices_.size());
 
     for (int j = 0; j < 4; ++j) {
         glm::vec4 pos(world_vertices_[j * 2], world_vertices_[j * 2 + 1], 0.0f, 1.0f);
@@ -174,7 +174,7 @@ void SpinePlugin::emitMeshAttachment(
     f32 a = skelColor.a * slotColor.a * attachColor.a * tintColor.a;
     u32 pc = packColor(r, g, b, a);
 
-    u16 base = static_cast<u16>(vertices_.size());
+    u32 base = static_cast<u32>(vertices_.size());
 
     if (clipper_.isClipping()) {
         clipper_.clipTriangles(world_vertices_.data(),
@@ -198,7 +198,7 @@ void SpinePlugin::emitMeshAttachment(
         }
 
         for (size_t j = 0; j < clippedTris.size(); ++j) {
-            indices_.push_back(static_cast<u16>(base + clippedTris[j]));
+            indices_.push_back(static_cast<u32>(base + clippedTris[j]));
         }
     } else {
         for (size_t j = 0; j < vertexCount; ++j) {
@@ -212,7 +212,7 @@ void SpinePlugin::emitMeshAttachment(
         }
 
         for (size_t j = 0; j < triangles.size(); ++j) {
-            indices_.push_back(static_cast<u16>(base + triangles[j]));
+            indices_.push_back(static_cast<u32>(base + triangles[j]));
         }
     }
 

--- a/src/esengine/renderer/plugins/SpinePlugin.hpp
+++ b/src/esengine/renderer/plugins/SpinePlugin.hpp
@@ -65,7 +65,7 @@ private:
     u32 batch_shader_id_ = 0;
 
     std::vector<BatchVertex> vertices_;
-    std::vector<u16> indices_;
+    std::vector<u32> indices_;
     std::vector<f32> world_vertices_;
     ::spine::SkeletonClipping clipper_;
 };

--- a/src/esengine/renderer/plugins/SpritePlugin.cpp
+++ b/src/esengine/renderer/plugins/SpritePlugin.cpp
@@ -152,9 +152,9 @@ void SpritePlugin::emitQuad(
     u32 vOff = buffers.appendVertices(LayoutId::Batch, verts, sizeof(verts));
     u32 baseVertex = vOff / sizeof(BatchVertex);
 
-    u16 indices[6];
+    u32 indices[6];
     for (u32 i = 0; i < 6; ++i) {
-        indices[i] = static_cast<u16>(baseVertex + QUAD_INDICES[i]);
+        indices[i] = static_cast<u32>(baseVertex + QUAD_INDICES[i]);
     }
     u32 iOff = buffers.appendIndices(LayoutId::Batch, indices, 6);
 
@@ -246,9 +246,9 @@ void SpritePlugin::emitNineSlice(
             u32 vOff = buffers.appendVertices(LayoutId::Batch, verts, sizeof(verts));
             u32 baseVert = vOff / sizeof(BatchVertex);
 
-            u16 indices[6];
+            u32 indices[6];
             for (u32 i = 0; i < 6; ++i) {
-                indices[i] = static_cast<u16>(baseVert + QUAD_INDICES[i]);
+                indices[i] = static_cast<u32>(baseVert + QUAD_INDICES[i]);
             }
             u32 iOff = buffers.appendIndices(LayoutId::Batch, indices, 6);
 
@@ -362,9 +362,9 @@ void SpritePlugin::emitTiledQuads(
             u32 vOff = buffers.appendVertices(LayoutId::Batch, verts, sizeof(verts));
             u32 baseVert = vOff / sizeof(BatchVertex);
 
-            u16 indices[6];
+            u32 indices[6];
             for (u32 i = 0; i < 6; ++i) {
-                indices[i] = static_cast<u16>(baseVert + QUAD_INDICES[i]);
+                indices[i] = static_cast<u32>(baseVert + QUAD_INDICES[i]);
             }
             u32 iOff = buffers.appendIndices(LayoutId::Batch, indices, 6);
 

--- a/src/esengine/renderer/plugins/SpritePlugin.hpp
+++ b/src/esengine/renderer/plugins/SpritePlugin.hpp
@@ -28,7 +28,7 @@ private:
         { 0.0f, 1.0f }
     };
 
-    static constexpr u16 QUAD_INDICES[6] = { 0, 1, 2, 2, 3, 0 };
+    static constexpr u32 QUAD_INDICES[6] = { 0, 1, 2, 2, 3, 0 };
 
     void emitQuad(
         TransientBufferPool& buffers, DrawList& draw_list,

--- a/src/esengine/renderer/plugins/TextPlugin.cpp
+++ b/src/esengine/renderer/plugins/TextPlugin.cpp
@@ -186,9 +186,9 @@ void TextPlugin::emitGlyphQuad(
     u32 vOff = buffers.appendVertices(LayoutId::Batch, verts, sizeof(verts));
     u32 baseVertex = vOff / sizeof(BatchVertex);
 
-    u16 indices[6];
+    u32 indices[6];
     for (u32 i = 0; i < 6; ++i) {
-        indices[i] = static_cast<u16>(baseVertex + QUAD_INDICES[i]);
+        indices[i] = static_cast<u32>(baseVertex + QUAD_INDICES[i]);
     }
     u32 iOff = buffers.appendIndices(LayoutId::Batch, indices, 6);
 

--- a/src/esengine/renderer/plugins/TextPlugin.hpp
+++ b/src/esengine/renderer/plugins/TextPlugin.hpp
@@ -14,7 +14,7 @@ public:
     void collect(RenderCollectContext& ctx) override;
 
 private:
-    static constexpr u16 QUAD_INDICES[6] = { 0, 1, 2, 2, 3, 0 };
+    static constexpr u32 QUAD_INDICES[6] = { 0, 1, 2, 2, 3, 0 };
 
     static u32 decodeUtf8(const char* data, u16 length, u16& pos);
 

--- a/src/esengine/renderer/plugins/TilemapRenderPlugin.cpp
+++ b/src/esengine/renderer/plugins/TilemapRenderPlugin.cpp
@@ -8,7 +8,7 @@
 
 namespace esengine {
 
-static constexpr u16 QUAD_IDX[6] = { 0, 1, 2, 2, 3, 0 };
+static constexpr u32 QUAD_IDX[6] = { 0, 1, 2, 2, 3, 0 };
 
 void TilemapRenderPlugin::init(RenderFrameContext& ctx) {
     batch_shader_id_ = ctx.batch_shader_id;
@@ -77,7 +77,7 @@ void TilemapRenderPlugin::rebuildChunk(
             if (flipH) { u0 += layer.uv_tile_width; su = -su; }
             if (flipV) { v0 += layer.uv_tile_height; sv = -sv; }
 
-            u16 baseVertex = static_cast<u16>(cache.vertices.size());
+            u32 baseVertex = static_cast<u32>(cache.vertices.size());
             cache.vertices.push_back({ {worldX - hw, worldY - hh}, packedColor, {u0, v0} });
             cache.vertices.push_back({ {worldX + hw, worldY - hh}, packedColor, {u0 + su, v0} });
             cache.vertices.push_back({ {worldX + hw, worldY + hh}, packedColor, {u0 + su, v0 + sv} });
@@ -179,9 +179,9 @@ void TilemapRenderPlugin::collect(RenderCollectContext& collect_ctx) {
 
                 if (cache.indices.empty()) continue;
 
-                u16 baseVertex = static_cast<u16>(vertices_.size());
+                u32 baseVertex = static_cast<u32>(vertices_.size());
                 vertices_.insert(vertices_.end(), cache.vertices.begin(), cache.vertices.end());
-                for (u16 idx : cache.indices) {
+                for (u32 idx : cache.indices) {
                     indices_.push_back(baseVertex + idx);
                 }
             }
@@ -194,7 +194,7 @@ void TilemapRenderPlugin::collect(RenderCollectContext& collect_ctx) {
         u32 baseVertex = vOff / sizeof(BatchVertex);
 
         for (auto& idx : indices_) {
-            idx = static_cast<u16>(idx + baseVertex);
+            idx = static_cast<u32>(idx + baseVertex);
         }
         u32 iOff = buffers.appendIndices(LayoutId::Batch, indices_.data(), static_cast<u32>(indices_.size()));
 

--- a/src/esengine/renderer/plugins/TilemapRenderPlugin.hpp
+++ b/src/esengine/renderer/plugins/TilemapRenderPlugin.hpp
@@ -24,7 +24,7 @@ public:
 private:
     struct ChunkCache {
         std::vector<BatchVertex> vertices;
-        std::vector<u16> indices;
+        std::vector<u32> indices;
         bool has_animated_tiles = false;
     };
 
@@ -41,7 +41,7 @@ private:
     LayerChunkMap layer_caches_;
 
     std::vector<BatchVertex> vertices_;
-    std::vector<u16> indices_;
+    std::vector<u32> indices_;
 };
 
 }  // namespace esengine

--- a/src/esengine/renderer/plugins/UIElementPlugin.cpp
+++ b/src/esengine/renderer/plugins/UIElementPlugin.cpp
@@ -154,9 +154,9 @@ void UIElementPlugin::emitQuad(
     u32 vOff = buffers.appendVertices(LayoutId::Batch, verts, sizeof(verts));
     u32 baseVertex = vOff / sizeof(BatchVertex);
 
-    u16 indices[6];
+    u32 indices[6];
     for (u32 i = 0; i < 6; ++i) {
-        indices[i] = static_cast<u16>(baseVertex + QUAD_INDICES[i]);
+        indices[i] = static_cast<u32>(baseVertex + QUAD_INDICES[i]);
     }
     u32 iOff = buffers.appendIndices(LayoutId::Batch, indices, 6);
 
@@ -255,9 +255,9 @@ void UIElementPlugin::emitNineSlice(
             u32 vOff = buffers.appendVertices(LayoutId::Batch, verts, sizeof(verts));
             u32 baseVert = vOff / sizeof(BatchVertex);
 
-            u16 indices[6];
+            u32 indices[6];
             for (u32 i = 0; i < 6; ++i) {
-                indices[i] = static_cast<u16>(baseVert + QUAD_INDICES[i]);
+                indices[i] = static_cast<u32>(baseVert + QUAD_INDICES[i]);
             }
             u32 iOff = buffers.appendIndices(LayoutId::Batch, indices, 6);
 

--- a/src/esengine/renderer/plugins/UIElementPlugin.hpp
+++ b/src/esengine/renderer/plugins/UIElementPlugin.hpp
@@ -28,7 +28,7 @@ private:
         { 0.0f, 1.0f }
     };
 
-    static constexpr u16 QUAD_INDICES[6] = { 0, 1, 2, 2, 3, 0 };
+    static constexpr u32 QUAD_INDICES[6] = { 0, 1, 2, 2, 3, 0 };
 
     static constexpr i32 UI_BASE_LAYER = 1000;
 


### PR DESCRIPTION
## What

All batched 2D content (sprites, UI, text, spine, tilemap, particles) streams into one shared Batch vertex/index buffer with **16-bit** indices. Once a frame accumulates more than **65,535 batched vertices**, every `baseVertex` cast truncates and the GPU reads garbage geometry — a silent corruption on any moderately busy scene (the audit's #1 latent renderer bug).

## Fix

- `TransientBufferPool`: `index_staging` `std::vector<u16>` → `u32`; `writeIndices`/`appendIndices` take `const u32*`; EBO sizing uses `sizeof(u32)`. The `const u32*` signature turns every still-`u16` index site into a compile error.
- Draw calls that read the pool EBO now use `GfxDataType::UnsignedInt` + `sizeof(u32)` stride: `DrawList` (merged batch draw) and `ShapePlugin::customDraw`.
- Widen every index array / base-vertex cast / index vector / quad-index constant to `u32` across all batched plugins and `RenderFrameSubmit`. Non-index `u16` (tile ids, text lengths, UTF-8 decode) left unchanged.

## Verification

- `emcc 5.0.0` web build compiles clean and links `esengine-core.wasm`. The `u32` signature surfaced the one site outside `plugins/` (`RenderFrameSubmit`) a manual sweep missed.
- `SpinePlugin` is excluded from the spine-off verification build; inspection-verified (identical mechanical change).

Part of the RC5 "abstractions / correct render path" track.