### PR TITLE
refactor(renderer): route Shader/Texture/Framebuffer through GfxDevice (RC5)

### DIFF
--- a/src/esengine/core/EstellaContext.cpp
+++ b/src/esengine/core/EstellaContext.cpp
@@ -10,6 +10,7 @@
 #include "Log.hpp"
 
 #include "../renderer/GLDevice.hpp"
+#include "../renderer/StateTracker.hpp"
 #include "../renderer/RenderContext.hpp"
 #include "../renderer/RenderFrame.hpp"
 #include "../renderer/ImmediateDraw.hpp"
@@ -81,17 +82,28 @@ bool EstellaContext::init(int webglContextHandle) {
 }
 
 void EstellaContext::initSubsystems() {
-    auto resourceManager = makeUnique<resource::ResourceManager>();
-    resourceManager->init();
-    services_.registerOwned<resource::ResourceManager>(std::move(resourceManager));
-
+    // GLDevice is created first: ResourceManager (the GPU-resource factory) and
+    // every other renderer subsystem borrow this single device.
     auto gfxDevice = makeUnique<GLDevice>();
     auto* gfxDevicePtr = gfxDevice.get();
     services_.registerOwned<GfxDevice>(std::move(gfxDevice));
 
+    auto resourceManager = makeUnique<resource::ResourceManager>();
+    resourceManager->init(*gfxDevicePtr);
+    services_.registerOwned<resource::ResourceManager>(std::move(resourceManager));
+
     auto renderContext = makeUnique<RenderContext>(*gfxDevicePtr);
     renderContext->init();
     services_.registerOwned<RenderContext>(std::move(renderContext));
+
+    // Single per-App GPU state cache. RenderContext::init() above already ran
+    // device_.init() (enabling the GL context), so the tracker's initial state
+    // sync is valid here. Every renderer subsystem borrows this one instance so
+    // the cache stays authoritative across the whole frame.
+    auto stateTracker = makeUnique<StateTracker>(*gfxDevicePtr);
+    stateTracker->init();
+    auto* statePtr = stateTracker.get();
+    services_.registerOwned<StateTracker>(std::move(stateTracker));
 
     services_.registerOwned<ecs::TransformSystem>(makeUnique<ecs::TransformSystem>());
     services_.registerOwned<ecs::UISystem>(makeUnique<ecs::UISystem>());
@@ -128,7 +140,7 @@ void EstellaContext::initSubsystems() {
     services_.registerOwned<tilemap::TiledMapLoader>(makeUnique<tilemap::TiledMapLoader>());
 #endif
 
-    auto renderFrame = makeUnique<RenderFrame>(*gfxDevicePtr, *rc, *rm);
+    auto renderFrame = makeUnique<RenderFrame>(*gfxDevicePtr, *statePtr, *rc, *rm);
     renderFrame->addPlugin(std::make_unique<SpritePlugin>());
     renderFrame->addPlugin(std::make_unique<UIElementPlugin>());
     renderFrame->addPlugin(std::make_unique<TextPlugin>());

--- a/src/esengine/renderer/Framebuffer.cpp
+++ b/src/esengine/renderer/Framebuffer.cpp
@@ -1,6 +1,8 @@
 /**
  * @file    Framebuffer.cpp
- * @brief   Framebuffer implementation for OpenGL/WebGL
+ * @brief   Framebuffer implementation (device-backed)
+ * @details Thin RAII handle over a GPU framebuffer + its attachments. All GL is
+ *          delegated to GfxDevice; this file contains no GL calls.
  *
  * @author  ESEngine Team
  * @date    2026
@@ -10,23 +12,8 @@
  */
 
 #include "Framebuffer.hpp"
+#include "GfxDevice.hpp"
 #include "../core/Log.hpp"
-
-#ifdef ES_PLATFORM_WEB
-    #include <GLES3/gl3.h>
-#else
-    #include <glad/glad.h>
-#endif
-
-#ifndef GL_DEPTH_STENCIL
-    #define GL_DEPTH_STENCIL 0x84F9
-#endif
-#ifndef GL_UNSIGNED_INT_24_8
-    #define GL_UNSIGNED_INT_24_8 0x84FA
-#endif
-#ifndef GL_DEPTH_STENCIL_ATTACHMENT
-    #define GL_DEPTH_STENCIL_ATTACHMENT 0x821A
-#endif
 
 namespace esengine {
 
@@ -39,7 +26,8 @@ Framebuffer::~Framebuffer() {
 }
 
 Framebuffer::Framebuffer(Framebuffer&& other) noexcept
-    : spec_(other.spec_),
+    : device_(other.device_),
+      spec_(other.spec_),
       framebufferId_(other.framebufferId_),
       colorAttachment_(other.colorAttachment_),
       depthAttachment_(other.depthAttachment_) {
@@ -51,6 +39,7 @@ Framebuffer::Framebuffer(Framebuffer&& other) noexcept
 Framebuffer& Framebuffer::operator=(Framebuffer&& other) noexcept {
     if (this != &other) {
         cleanup();
+        device_ = other.device_;
         spec_ = other.spec_;
         framebufferId_ = other.framebufferId_;
         colorAttachment_ = other.colorAttachment_;
@@ -66,8 +55,9 @@ Framebuffer& Framebuffer::operator=(Framebuffer&& other) noexcept {
 // Creation
 // =============================================================================
 
-Unique<Framebuffer> Framebuffer::create(const FramebufferSpec& spec) {
+Unique<Framebuffer> Framebuffer::create(GfxDevice& device, const FramebufferSpec& spec) {
     auto framebuffer = makeUnique<Framebuffer>();
+    framebuffer->device_ = &device;
     framebuffer->spec_ = spec;
 
     if (!framebuffer->initialize()) {
@@ -83,11 +73,11 @@ Unique<Framebuffer> Framebuffer::create(const FramebufferSpec& spec) {
 // =============================================================================
 
 void Framebuffer::bind() const {
-    glBindFramebuffer(GL_FRAMEBUFFER, framebufferId_);
+    if (device_) device_->bindFramebuffer(framebufferId_);
 }
 
 void Framebuffer::unbind() const {
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (device_) device_->bindFramebuffer(0);
 }
 
 void Framebuffer::resize(u32 width, u32 height) {
@@ -110,64 +100,57 @@ void Framebuffer::resize(u32 width, u32 height) {
 // =============================================================================
 
 bool Framebuffer::initialize() {
-    glGenFramebuffers(1, &framebufferId_);
-    glBindFramebuffer(GL_FRAMEBUFFER, framebufferId_);
+    const TextureFilter filter = spec_.linearFilter ? TextureFilter::Linear : TextureFilter::Nearest;
 
-    glGenTextures(1, &colorAttachment_);
-    glBindTexture(GL_TEXTURE_2D, colorAttachment_);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, spec_.width, spec_.height, 0,
-                 GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-    GLenum filter = spec_.linearFilter ? GL_LINEAR : GL_NEAREST;
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                          GL_TEXTURE_2D, colorAttachment_, 0);
+    framebufferId_ = device_->createFramebuffer();
+    device_->bindFramebuffer(framebufferId_);
+
+    colorAttachment_ = device_->createTexture();
+    device_->texImage2D(colorAttachment_, spec_.width, spec_.height, GfxPixelFormat::RGBA8, nullptr);
+    device_->setTextureParams(colorAttachment_, filter, filter,
+                              TextureWrap::ClampToEdge, TextureWrap::ClampToEdge);
+    device_->framebufferTexture2D(framebufferId_, GfxAttachment::Color0, colorAttachment_);
 
     if (spec_.depthStencil) {
-        glGenTextures(1, &depthAttachment_);
-        glBindTexture(GL_TEXTURE_2D, depthAttachment_);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, spec_.width, spec_.height, 0,
-                     GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
-                              GL_TEXTURE_2D, depthAttachment_, 0);
+        depthAttachment_ = device_->createTexture();
+        device_->texImage2D(depthAttachment_, spec_.width, spec_.height,
+                            GfxPixelFormat::Depth24Stencil8, nullptr);
+        device_->setTextureParams(depthAttachment_, TextureFilter::Nearest, TextureFilter::Nearest,
+                                  TextureWrap::ClampToEdge, TextureWrap::ClampToEdge);
+        device_->framebufferTexture2D(framebufferId_, GfxAttachment::DepthStencil, depthAttachment_);
     }
 
-    GLenum err = glGetError();
-    if (err != GL_NO_ERROR) {
-        ES_LOG_ERROR("Framebuffer GL error before completeness check: 0x{:X} (size: {}x{})", err, spec_.width, spec_.height);
+    if (u32 err = device_->getError(); err != 0) {
+        ES_LOG_ERROR("Framebuffer GL error before completeness check: 0x{:X} (size: {}x{})",
+                     err, spec_.width, spec_.height);
     }
 
-    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-    if (status != GL_FRAMEBUFFER_COMPLETE) {
-        ES_LOG_ERROR("Framebuffer is incomplete! Status: 0x{:X} (size: {}x{})", status, spec_.width, spec_.height);
-        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (!device_->checkFramebufferStatus()) {
+        ES_LOG_ERROR("Framebuffer is incomplete! (size: {}x{})", spec_.width, spec_.height);
+        device_->bindFramebuffer(0);
         cleanup();
         return false;
     }
 
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    device_->bindFramebuffer(0);
     return true;
 }
 
 void Framebuffer::cleanup() {
+    if (!device_) return;
+
     if (colorAttachment_) {
-        glDeleteTextures(1, &colorAttachment_);
+        device_->deleteTexture(colorAttachment_);
         colorAttachment_ = 0;
     }
 
     if (depthAttachment_) {
-        glDeleteTextures(1, &depthAttachment_);
+        device_->deleteTexture(depthAttachment_);
         depthAttachment_ = 0;
     }
 
     if (framebufferId_) {
-        glDeleteFramebuffers(1, &framebufferId_);
+        device_->deleteFramebuffer(framebufferId_);
         framebufferId_ = 0;
     }
 }

--- a/src/esengine/renderer/Framebuffer.hpp
+++ b/src/esengine/renderer/Framebuffer.hpp
@@ -21,6 +21,8 @@
 
 namespace esengine {
 
+class GfxDevice;
+
 // =============================================================================
 // Framebuffer Specification
 // =============================================================================
@@ -103,7 +105,7 @@ public:
      * @details Creates framebuffer with color attachment and optional
      *          depth/stencil attachment based on spec.
      */
-    static Unique<Framebuffer> create(const FramebufferSpec& spec);
+    static Unique<Framebuffer> create(GfxDevice& device, const FramebufferSpec& spec);
 
     // =========================================================================
     // Operations
@@ -166,6 +168,7 @@ private:
      */
     void cleanup();
 
+    GfxDevice* device_ = nullptr;  ///< Set by create(); all GL goes through it.
     FramebufferSpec spec_;
     u32 framebufferId_ = 0;
     u32 colorAttachment_ = 0;

--- a/src/esengine/renderer/GLDevice.cpp
+++ b/src/esengine/renderer/GLDevice.cpp
@@ -13,6 +13,19 @@
 #include "OpenGLHeaders.hpp"
 #include "../core/Log.hpp"
 
+#ifndef GL_DEPTH_STENCIL
+    #define GL_DEPTH_STENCIL 0x84F9
+#endif
+#ifndef GL_UNSIGNED_INT_24_8
+    #define GL_UNSIGNED_INT_24_8 0x84FA
+#endif
+#ifndef GL_DEPTH_STENCIL_ATTACHMENT
+    #define GL_DEPTH_STENCIL_ATTACHMENT 0x821A
+#endif
+#ifndef GL_UNPACK_FLIP_Y_WEBGL
+    #define GL_UNPACK_FLIP_Y_WEBGL 0x9240
+#endif
+
 namespace esengine {
 
 // =============================================================================
@@ -104,16 +117,39 @@ GLPixelFormatInfo toGLPixelFormat(GfxPixelFormat fmt) {
     case GfxPixelFormat::RGB8:             return { GL_RGB8,              GL_RGB,             GL_UNSIGNED_BYTE };
     case GfxPixelFormat::RGBA8:            return { GL_RGBA8,             GL_RGBA,            GL_UNSIGNED_BYTE };
     case GfxPixelFormat::DepthComponent24: return { GL_DEPTH_COMPONENT24, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT };
+    case GfxPixelFormat::Depth24Stencil8:  return { GL_DEPTH24_STENCIL8,  GL_DEPTH_STENCIL,   GL_UNSIGNED_INT_24_8 };
     default:                               return { GL_RGBA8,             GL_RGBA,            GL_UNSIGNED_BYTE };
     }
 }
 
 GLenum toGLAttachment(GfxAttachment attachment) {
     switch (attachment) {
-    case GfxAttachment::Color0: return GL_COLOR_ATTACHMENT0;
-    case GfxAttachment::Depth:  return GL_DEPTH_ATTACHMENT;
+    case GfxAttachment::Color0:       return GL_COLOR_ATTACHMENT0;
+    case GfxAttachment::Depth:        return GL_DEPTH_ATTACHMENT;
+    case GfxAttachment::DepthStencil: return GL_DEPTH_STENCIL_ATTACHMENT;
     default: return GL_COLOR_ATTACHMENT0;
     }
+}
+
+std::string readShaderInfoLog(GLuint shader) {
+    GLint logLength = 0;
+    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength <= 0) return {};
+    std::string log(static_cast<size_t>(logLength), '\0');
+    glGetShaderInfoLog(shader, logLength, nullptr, log.data());
+    // Drop the trailing NUL glGetShaderInfoLog writes inside the buffer.
+    if (!log.empty() && log.back() == '\0') log.pop_back();
+    return log;
+}
+
+std::string readProgramInfoLog(GLuint program) {
+    GLint logLength = 0;
+    glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
+    if (logLength <= 0) return {};
+    std::string log(static_cast<size_t>(logLength), '\0');
+    glGetProgramInfoLog(program, logLength, nullptr, log.data());
+    if (!log.empty() && log.back() == '\0') log.pop_back();
+    return log;
 }
 
 }  // namespace
@@ -143,6 +179,10 @@ void GLDevice::setViewport(i32 x, i32 y, u32 w, u32 h) {
 
 void GLDevice::setClearColor(f32 r, f32 g, f32 b, f32 a) {
     glClearColor(r, g, b, a);
+}
+
+void GLDevice::setClearStencil(i32 value) {
+    glClearStencil(value);
 }
 
 void GLDevice::clear(bool color, bool depth, bool stencil) {
@@ -275,12 +315,84 @@ void GLDevice::bindTexture(u32 slot, u32 textureId) {
 // Shader Program
 // =============================================================================
 
+u32 GLDevice::createProgram(const char* vertexSrc, const char* fragmentSrc,
+                            const GfxAttribBinding* bindings, u32 bindingCount,
+                            std::string* outLog, GfxShaderStage* outFailedStage) {
+    auto setFailure = [&](GfxShaderStage stage, std::string&& log) {
+        if (outLog) *outLog = std::move(log);
+        if (outFailedStage) *outFailedStage = stage;
+    };
+
+    GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(vertexShader, 1, &vertexSrc, nullptr);
+    glCompileShader(vertexShader);
+
+    GLint success = 0;
+    glGetShaderiv(vertexShader, GL_COMPILE_STATUS, &success);
+    if (!success) {
+        std::string log = readShaderInfoLog(vertexShader);
+        ES_LOG_ERROR("Vertex shader compilation failed: {}", log);
+        setFailure(GfxShaderStage::Vertex, std::move(log));
+        glDeleteShader(vertexShader);
+        return 0;
+    }
+
+    GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(fragmentShader, 1, &fragmentSrc, nullptr);
+    glCompileShader(fragmentShader);
+
+    glGetShaderiv(fragmentShader, GL_COMPILE_STATUS, &success);
+    if (!success) {
+        std::string log = readShaderInfoLog(fragmentShader);
+        ES_LOG_ERROR("Fragment shader compilation failed: {}", log);
+        setFailure(GfxShaderStage::Fragment, std::move(log));
+        glDeleteShader(vertexShader);
+        glDeleteShader(fragmentShader);
+        return 0;
+    }
+
+    GLuint program = glCreateProgram();
+    glAttachShader(program, vertexShader);
+    glAttachShader(program, fragmentShader);
+
+    for (u32 i = 0; i < bindingCount; ++i) {
+        glBindAttribLocation(program, bindings[i].index, bindings[i].name);
+    }
+
+    glLinkProgram(program);
+
+    glGetProgramiv(program, GL_LINK_STATUS, &success);
+    if (!success) {
+        std::string log = readProgramInfoLog(program);
+        ES_LOG_ERROR("Shader program linking failed: {}", log);
+        setFailure(GfxShaderStage::Link, std::move(log));
+        glDeleteShader(vertexShader);
+        glDeleteShader(fragmentShader);
+        glDeleteProgram(program);
+        return 0;
+    }
+
+    glDeleteShader(vertexShader);
+    glDeleteShader(fragmentShader);
+
+    if (outFailedStage) *outFailedStage = GfxShaderStage::None;
+    return static_cast<u32>(program);
+}
+
+void GLDevice::deleteProgram(u32 programId) {
+    if (programId != 0) glDeleteProgram(programId);
+}
+
 void GLDevice::useProgram(u32 programId) {
     glUseProgram(programId);
 }
 
 i32 GLDevice::getUniformLocation(u32 programId, const char* name) {
     return glGetUniformLocation(programId, name);
+}
+
+i32 GLDevice::getAttribLocation(u32 programId, const char* name) {
+    return glGetAttribLocation(programId, name);
 }
 
 void GLDevice::setUniform1i(i32 location, i32 value) {
@@ -509,6 +621,15 @@ void GLDevice::generateMipmaps(u32 textureId) {
 
 void GLDevice::pixelStorei(u32 pname, i32 param) {
     glPixelStorei(pname, param);
+}
+
+void GLDevice::setUnpackFlipY(bool enabled) {
+#ifdef ES_PLATFORM_WEB
+    glPixelStorei(GL_UNPACK_FLIP_Y_WEBGL, enabled ? GL_TRUE : GL_FALSE);
+#else
+    // Native image data is flipped CPU-side at load (stbi_set_flip_vertically_on_load).
+    (void)enabled;
+#endif
 }
 
 // =============================================================================

--- a/src/esengine/renderer/GLDevice.hpp
+++ b/src/esengine/renderer/GLDevice.hpp
@@ -36,6 +36,7 @@ public:
 
     void setViewport(i32 x, i32 y, u32 w, u32 h) override;
     void setClearColor(f32 r, f32 g, f32 b, f32 a) override;
+    void setClearStencil(i32 value) override;
     void clear(bool color, bool depth, bool stencil) override;
 
     void setBlendEnabled(bool enabled) override;
@@ -58,8 +59,13 @@ public:
 
     void bindTexture(u32 slot, u32 textureId) override;
 
+    u32 createProgram(const char* vertexSrc, const char* fragmentSrc,
+                      const GfxAttribBinding* bindings, u32 bindingCount,
+                      std::string* outLog, GfxShaderStage* outFailedStage) override;
+    void deleteProgram(u32 programId) override;
     void useProgram(u32 programId) override;
     i32 getUniformLocation(u32 programId, const char* name) override;
+    i32 getAttribLocation(u32 programId, const char* name) override;
     void setUniform1i(i32 location, i32 value) override;
     void setUniform1f(i32 location, f32 value) override;
     void setUniform2f(i32 location, f32 x, f32 y) override;
@@ -100,6 +106,7 @@ public:
                           TextureWrap wrapS, TextureWrap wrapT) override;
     void generateMipmaps(u32 textureId) override;
     void pixelStorei(u32 pname, i32 param) override;
+    void setUnpackFlipY(bool enabled) override;
 
     u32 createFramebuffer() override;
     void deleteFramebuffer(u32 fboId) override;

--- a/src/esengine/renderer/GfxDevice.hpp
+++ b/src/esengine/renderer/GfxDevice.hpp
@@ -22,6 +22,7 @@
 #include "GfxEnums.hpp"
 #include "Texture.hpp"
 
+#include <string>
 #include <vector>
 
 namespace esengine {
@@ -59,6 +60,9 @@ public:
 
     /** @brief Sets the clear color */
     virtual void setClearColor(f32 r, f32 g, f32 b, f32 a) = 0;
+
+    /** @brief Sets the value written to the stencil buffer by clear() */
+    virtual void setClearStencil(i32 value) = 0;
 
     /** @brief Clears framebuffer attachments */
     virtual void clear(bool color, bool depth, bool stencil) = 0;
@@ -133,11 +137,34 @@ public:
     // Shader Program
     // =========================================================================
 
+    /**
+     * @brief Compiles and links a GPU program from GLSL sources.
+     * @param vertexSrc   Vertex shader GLSL source (null-terminated).
+     * @param fragmentSrc Fragment shader GLSL source (null-terminated).
+     * @param bindings    Attribute location bindings applied before link (may be null if count==0).
+     * @param bindingCount Number of entries in @p bindings.
+     * @param outLog      Optional; receives the driver info log on failure.
+     * @param outFailedStage Optional; receives the stage that rejected the source.
+     * @return The linked program id, or 0 on failure.
+     * @details Collapses the multi-step GL shader protocol behind the device so
+     *          no upper layer ever issues raw shader GL. Uniform reflection is a
+     *          separate call (getActiveUniforms).
+     */
+    virtual u32 createProgram(const char* vertexSrc, const char* fragmentSrc,
+                              const GfxAttribBinding* bindings, u32 bindingCount,
+                              std::string* outLog, GfxShaderStage* outFailedStage) = 0;
+
+    /** @brief Deletes a shader program */
+    virtual void deleteProgram(u32 programId) = 0;
+
     /** @brief Binds a shader program */
     virtual void useProgram(u32 programId) = 0;
 
     /** @brief Gets a uniform location by name */
     virtual i32 getUniformLocation(u32 programId, const char* name) = 0;
+
+    /** @brief Gets a vertex attribute location by name (-1 if not found) */
+    virtual i32 getAttribLocation(u32 programId, const char* name) = 0;
 
     /** @brief Sets an integer uniform */
     virtual void setUniform1i(i32 location, i32 value) = 0;
@@ -249,6 +276,14 @@ public:
 
     /** @brief Sets pixel store parameter */
     virtual void pixelStorei(u32 pname, i32 param) = 0;
+
+    /**
+     * @brief Toggles vertical flip on subsequent texture uploads.
+     * @details WebGL-only (GL_UNPACK_FLIP_Y_WEBGL); a no-op on native, where
+     *          image data is flipped CPU-side at load time. Keeping the WebGL
+     *          constant inside the device avoids leaking it to upper layers.
+     */
+    virtual void setUnpackFlipY(bool enabled) = 0;
 
     // =========================================================================
     // Framebuffer

--- a/src/esengine/renderer/GfxEnums.hpp
+++ b/src/esengine/renderer/GfxEnums.hpp
@@ -77,6 +77,7 @@ enum class GfxPixelFormat : u8 {
     RGB8,
     RGBA8,
     DepthComponent24,
+    Depth24Stencil8,
 };
 
 // =============================================================================
@@ -86,6 +87,28 @@ enum class GfxPixelFormat : u8 {
 enum class GfxAttachment : u8 {
     Color0,
     Depth,
+    DepthStencil,
+};
+
+// =============================================================================
+// Shader Program Creation
+// =============================================================================
+
+/**
+ * @brief Vertex attribute location binding applied before a program is linked.
+ * @note `name` is borrowed for the duration of the createProgram() call only.
+ */
+struct GfxAttribBinding {
+    u32 index = 0;
+    const char* name = nullptr;
+};
+
+/** @brief Which pipeline stage rejected a program during createProgram(). */
+enum class GfxShaderStage : u8 {
+    None,
+    Vertex,
+    Fragment,
+    Link,
 };
 
 // =============================================================================

--- a/src/esengine/renderer/PostProcessPipeline.cpp
+++ b/src/esengine/renderer/PostProcessPipeline.cpp
@@ -83,7 +83,7 @@ void PostProcessPipeline::ensureFBOs() {
         origSpec.height = height_;
         origSpec.depthStencil = false;
 
-        fboOriginal_ = Framebuffer::create(origSpec);
+        fboOriginal_ = Framebuffer::create(device_, origSpec);
         if (!fboOriginal_) {
             ES_LOG_ERROR("PostProcessPipeline: Failed to create original FBO");
             return;
@@ -98,8 +98,8 @@ void PostProcessPipeline::ensureFBOs() {
     spec.height = height_;
     spec.depthStencil = false;
 
-    fboA_ = Framebuffer::create(spec);
-    fboB_ = Framebuffer::create(spec);
+    fboA_ = Framebuffer::create(device_, spec);
+    fboB_ = Framebuffer::create(device_, spec);
 
     if (!fboA_ || !fboB_) {
         ES_LOG_ERROR("PostProcessPipeline: Failed to create framebuffers");
@@ -422,7 +422,7 @@ void PostProcessPipeline::ensureScreenFBO() {
     spec.height = height_;
     spec.depthStencil = false;
 
-    screenFBO_ = Framebuffer::create(spec);
+    screenFBO_ = Framebuffer::create(device_, spec);
     if (!screenFBO_) {
         ES_LOG_ERROR("PostProcessPipeline: Failed to create screen FBO");
         return;

--- a/src/esengine/renderer/RenderContext.cpp
+++ b/src/esengine/renderer/RenderContext.cpp
@@ -90,17 +90,20 @@ void RenderContext::initQuadData() {
 void RenderContext::initShaders() {
     auto colorParsed = resource::ShaderParser::parse(ShaderEmbeds::COLOR);
     colorShader_ = Shader::create(
+        device_,
         resource::ShaderParser::assembleStage(colorParsed, resource::ShaderStage::Vertex),
         resource::ShaderParser::assembleStage(colorParsed, resource::ShaderStage::Fragment)
     );
 
     auto spriteParsed = resource::ShaderParser::parse(ShaderEmbeds::SPRITE);
     textureShader_ = Shader::create(
+        device_,
         resource::ShaderParser::assembleStage(spriteParsed, resource::ShaderStage::Vertex),
         resource::ShaderParser::assembleStage(spriteParsed, resource::ShaderStage::Fragment)
     );
 
     extMeshShader_ = Shader::createWithBindings(
+        device_,
         ShaderSources::EXT_MESH_VERTEX,
         ShaderSources::EXT_MESH_FRAGMENT,
         {{0, "a_position"}, {1, "a_texCoord"}, {2, "a_color"}}

--- a/src/esengine/renderer/RenderFrame.cpp
+++ b/src/esengine/renderer/RenderFrame.cpp
@@ -59,12 +59,14 @@ bool Frustum::intersectsAABB(const glm::vec3& center, const glm::vec3& halfExten
     return true;
 }
 
-RenderFrame::RenderFrame(GfxDevice& device, RenderContext& context, resource::ResourceManager& resource_manager)
+RenderFrame::RenderFrame(GfxDevice& device, StateTracker& state_tracker, RenderContext& context,
+                         resource::ResourceManager& resource_manager)
     : device_(device)
     , context_(context)
     , resource_manager_(resource_manager)
-    , state_tracker_(device)
+    , state_tracker_(state_tracker)
     , pool_(device) {
+    target_manager_.setDevice(device);
 }
 
 RenderFrame::~RenderFrame() {
@@ -75,7 +77,8 @@ void RenderFrame::init(u32 width, u32 height) {
     width_ = width;
     height_ = height;
 
-    state_tracker_.init();
+    // state_tracker_ is inited once by EstellaContext (its owner); flush()/replay
+    // reset() it each frame, so no per-RenderFrame init is needed here.
 
 #ifdef ES_ENABLE_POSTPROCESS
     post_process_ = makeUnique<PostProcessPipeline>(device_, context_, resource_manager_);

--- a/src/esengine/renderer/RenderFrame.hpp
+++ b/src/esengine/renderer/RenderFrame.hpp
@@ -52,7 +52,8 @@ public:
         u32 culled = 0;
     };
 
-    RenderFrame(GfxDevice& device, RenderContext& context, resource::ResourceManager& resource_manager);
+    RenderFrame(GfxDevice& device, StateTracker& state_tracker, RenderContext& context,
+                resource::ResourceManager& resource_manager);
     ~RenderFrame();
 
     RenderFrame(const RenderFrame&) = delete;
@@ -124,7 +125,7 @@ private:
     GfxDevice& device_;
     RenderContext& context_;
     resource::ResourceManager& resource_manager_;
-    StateTracker state_tracker_;
+    StateTracker& state_tracker_;  // owned by EstellaContext (per-App service)
 
 #ifdef ES_ENABLE_POSTPROCESS
     Unique<PostProcessPipeline> post_process_;

--- a/src/esengine/renderer/RenderTarget.cpp
+++ b/src/esengine/renderer/RenderTarget.cpp
@@ -2,7 +2,7 @@
 
 namespace esengine {
 
-void RenderTarget::init(u32 width, u32 height, bool depth, bool linearFilter) {
+void RenderTarget::init(GfxDevice& device, u32 width, u32 height, bool depth, bool linearFilter) {
     width_ = width;
     height_ = height;
     has_depth_ = depth;
@@ -14,7 +14,7 @@ void RenderTarget::init(u32 width, u32 height, bool depth, bool linearFilter) {
     spec.depthStencil = depth;
     spec.linearFilter = linearFilter;
 
-    framebuffer_ = Framebuffer::create(spec);
+    framebuffer_ = Framebuffer::create(device, spec);
 }
 
 void RenderTarget::shutdown() {
@@ -70,7 +70,7 @@ RenderTargetManager::Handle RenderTargetManager::create(u32 width, u32 height, b
     }
 
     auto target = makeUnique<RenderTarget>();
-    target->init(width, height, depth, linearFilter);
+    target->init(*device_, width, height, depth, linearFilter);
 
     usize index = handle - 1;
     if (index < targets_.size()) {

--- a/src/esengine/renderer/RenderTarget.hpp
+++ b/src/esengine/renderer/RenderTarget.hpp
@@ -18,7 +18,7 @@ public:
     RenderTarget(RenderTarget&&) = default;
     RenderTarget& operator=(RenderTarget&&) = default;
 
-    void init(u32 width, u32 height, bool depth = true, bool linearFilter = false);
+    void init(GfxDevice& device, u32 width, u32 height, bool depth = true, bool linearFilter = false);
     void shutdown();
 
     void bind();
@@ -50,12 +50,16 @@ public:
     RenderTargetManager() = default;
     ~RenderTargetManager() = default;
 
+    /** @brief Binds the device used to create render targets. Call once at setup. */
+    void setDevice(GfxDevice& device) { device_ = &device; }
+
     Handle create(u32 width, u32 height, bool depth = true, bool linearFilter = false);
     RenderTarget* get(Handle handle);
     void release(Handle handle);
     bool isValid(Handle handle) const;
 
 private:
+    GfxDevice* device_ = nullptr;
     std::vector<Unique<RenderTarget>> targets_;
     std::vector<Handle> free_list_;
     Handle next_handle_ = 1;

--- a/src/esengine/renderer/Shader.cpp
+++ b/src/esengine/renderer/Shader.cpp
@@ -1,7 +1,9 @@
 /**
  * @file    Shader.cpp
- * @brief   Shader program implementation for OpenGL/WebGL
- * @details Implements shader compilation, linking, and uniform management.
+ * @brief   Shader program implementation
+ * @details Thin RAII handle over a GPU program. All GL is delegated to GfxDevice
+ *          (compile/link via createProgram, uniforms via setUniform*, reflection
+ *          via getActiveUniforms) — this file contains no GL calls.
  *
  * @author  ESEngine Team
  * @date    2025
@@ -11,30 +13,24 @@
  */
 
 #include "Shader.hpp"
+#include "GfxDevice.hpp"
 #include "../core/Log.hpp"
 
-#ifdef ES_PLATFORM_WEB
-    #include <GLES3/gl3.h>
-#else
-    #ifdef _WIN32
-        #include <windows.h>
-    #endif
-    #include <glad/glad.h>
-#endif
-
 #include <fstream>
+#include <vector>
 
 namespace esengine {
 
 Shader::~Shader() {
-    if (programId_ != 0) {
-        glDeleteProgram(programId_);
+    if (programId_ != 0 && device_) {
+        device_->deleteProgram(programId_);
         programId_ = 0;
     }
 }
 
 Shader::Shader(Shader&& other) noexcept
-    : programId_(other.programId_)
+    : device_(other.device_)
+    , programId_(other.programId_)
     , uniformCache_(std::move(other.uniformCache_))
     , attribCache_(std::move(other.attribCache_))
     , activeUniforms_(std::move(other.activeUniforms_)) {
@@ -43,9 +39,10 @@ Shader::Shader(Shader&& other) noexcept
 
 Shader& Shader::operator=(Shader&& other) noexcept {
     if (this != &other) {
-        if (programId_ != 0) {
-            glDeleteProgram(programId_);
+        if (programId_ != 0 && device_) {
+            device_->deleteProgram(programId_);
         }
+        device_ = other.device_;
         programId_ = other.programId_;
         uniformCache_ = std::move(other.uniformCache_);
         attribCache_ = std::move(other.attribCache_);
@@ -55,24 +52,28 @@ Shader& Shader::operator=(Shader&& other) noexcept {
     return *this;
 }
 
-Unique<Shader> Shader::create(const std::string& vertexSrc, const std::string& fragmentSrc) {
+Unique<Shader> Shader::create(GfxDevice& device, const std::string& vertexSrc, const std::string& fragmentSrc) {
     auto shader = makeUnique<Shader>();
+    shader->device_ = &device;
     if (!shader->compile(vertexSrc, fragmentSrc)) {
         return nullptr;
     }
     return shader;
 }
 
-Unique<Shader> Shader::createWithBindings(const std::string& vertexSrc, const std::string& fragmentSrc,
-                                            std::initializer_list<AttribBinding> bindings) {
+Unique<Shader> Shader::createWithBindings(GfxDevice& device,
+                                          const std::string& vertexSrc, const std::string& fragmentSrc,
+                                          std::initializer_list<AttribBinding> bindings) {
     auto shader = makeUnique<Shader>();
+    shader->device_ = &device;
     if (!shader->compile(vertexSrc, fragmentSrc, bindings)) {
         return nullptr;
     }
     return shader;
 }
 
-Unique<Shader> Shader::createFromFile(const std::string& vertexPath, const std::string& fragmentPath) {
+Unique<Shader> Shader::createFromFile(GfxDevice& device,
+                                      const std::string& vertexPath, const std::string& fragmentPath) {
     auto readFile = [](const std::string& filepath) -> std::string {
         std::ifstream file(filepath, std::ios::in | std::ios::binary);
         if (!file.is_open()) {
@@ -108,105 +109,47 @@ Unique<Shader> Shader::createFromFile(const std::string& vertexPath, const std::
         return nullptr;
     }
 
-    return create(vertexSrc, fragmentSrc);
+    return create(device, vertexSrc, fragmentSrc);
 }
 
 void Shader::bind() const {
-    glUseProgram(programId_);
+    // NOTE: routes through the device, not the StateTracker cache yet. Once the
+    // legacy Renderer/BatchRenderer2D are retired, the remaining bind sites flip
+    // to StateTracker::useProgram and this method is removed (RC5).
+    if (device_) device_->useProgram(programId_);
 }
 
 void Shader::unbind() const {
-    glUseProgram(0);
+    if (device_) device_->useProgram(0);
 }
-
-namespace {
-
-std::string readShaderInfoLog(GLuint shader) {
-    GLint logLength = 0;
-    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLength);
-    if (logLength <= 0) return {};
-    std::string log(static_cast<size_t>(logLength), '\0');
-    glGetShaderInfoLog(shader, logLength, nullptr, log.data());
-    // Drop the trailing NUL glGetShaderInfoLog writes inside the buffer.
-    if (!log.empty() && log.back() == '\0') log.pop_back();
-    return log;
-}
-
-std::string readProgramInfoLog(GLuint program) {
-    GLint logLength = 0;
-    glGetProgramiv(program, GL_INFO_LOG_LENGTH, &logLength);
-    if (logLength <= 0) return {};
-    std::string log(static_cast<size_t>(logLength), '\0');
-    glGetProgramInfoLog(program, logLength, nullptr, log.data());
-    if (!log.empty() && log.back() == '\0') log.pop_back();
-    return log;
-}
-
-}  // namespace
 
 bool Shader::compile(const std::string& vertexSrc, const std::string& fragmentSrc,
                      std::initializer_list<AttribBinding> bindings,
                      std::string* outLog,
                      ShaderStageFailure* outFailedStage) {
-    auto setFailure = [&](ShaderStageFailure stage, std::string&& log) {
-        if (outLog) *outLog = std::move(log);
-        if (outFailedStage) *outFailedStage = stage;
-    };
-
-    GLuint vertexShader = glCreateShader(GL_VERTEX_SHADER);
-    const char* vertexSrcPtr = vertexSrc.c_str();
-    glShaderSource(vertexShader, 1, &vertexSrcPtr, nullptr);
-    glCompileShader(vertexShader);
-
-    GLint success;
-    glGetShaderiv(vertexShader, GL_COMPILE_STATUS, &success);
-    if (!success) {
-        std::string log = readShaderInfoLog(vertexShader);
-        ES_LOG_ERROR("Vertex shader compilation failed: {}", log);
-        setFailure(ShaderStageFailure::Vertex, std::move(log));
-        glDeleteShader(vertexShader);
-        return false;
-    }
-
-    GLuint fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
-    const char* fragmentSrcPtr = fragmentSrc.c_str();
-    glShaderSource(fragmentShader, 1, &fragmentSrcPtr, nullptr);
-    glCompileShader(fragmentShader);
-
-    glGetShaderiv(fragmentShader, GL_COMPILE_STATUS, &success);
-    if (!success) {
-        std::string log = readShaderInfoLog(fragmentShader);
-        ES_LOG_ERROR("Fragment shader compilation failed: {}", log);
-        setFailure(ShaderStageFailure::Fragment, std::move(log));
-        glDeleteShader(vertexShader);
-        glDeleteShader(fragmentShader);
-        return false;
-    }
-
-    programId_ = glCreateProgram();
-    glAttachShader(programId_, vertexShader);
-    glAttachShader(programId_, fragmentShader);
-
+    std::vector<GfxAttribBinding> binds;
+    binds.reserve(bindings.size());
     for (const auto& b : bindings) {
-        glBindAttribLocation(programId_, b.index, b.name);
+        binds.push_back(GfxAttribBinding{b.index, b.name});
     }
 
-    glLinkProgram(programId_);
+    GfxShaderStage stage = GfxShaderStage::None;
+    programId_ = device_->createProgram(vertexSrc.c_str(), fragmentSrc.c_str(),
+                                        binds.data(), static_cast<u32>(binds.size()),
+                                        outLog, &stage);
 
-    glGetProgramiv(programId_, GL_LINK_STATUS, &success);
-    if (!success) {
-        std::string log = readProgramInfoLog(programId_);
-        ES_LOG_ERROR("Shader program linking failed: {}", log);
-        setFailure(ShaderStageFailure::Link, std::move(log));
-        glDeleteShader(vertexShader);
-        glDeleteShader(fragmentShader);
-        glDeleteProgram(programId_);
-        programId_ = 0;
+    if (outFailedStage) {
+        switch (stage) {
+        case GfxShaderStage::Vertex:   *outFailedStage = ShaderStageFailure::Vertex; break;
+        case GfxShaderStage::Fragment: *outFailedStage = ShaderStageFailure::Fragment; break;
+        case GfxShaderStage::Link:     *outFailedStage = ShaderStageFailure::Link; break;
+        case GfxShaderStage::None:     *outFailedStage = ShaderStageFailure::None; break;
+        }
+    }
+
+    if (programId_ == 0) {
         return false;
     }
-
-    glDeleteShader(vertexShader);
-    glDeleteShader(fragmentShader);
 
     reflectActiveUniforms();
 
@@ -215,11 +158,13 @@ bool Shader::compile(const std::string& vertexSrc, const std::string& fragmentSr
     return true;
 }
 
-ShaderCompileOutcome Shader::createEx(const std::string& vertexSrc,
+ShaderCompileOutcome Shader::createEx(GfxDevice& device,
+                                      const std::string& vertexSrc,
                                       const std::string& fragmentSrc,
                                       std::initializer_list<AttribBinding> bindings) {
     ShaderCompileOutcome outcome;
     auto shader = makeUnique<Shader>();
+    shader->device_ = &device;
     if (!shader->compile(vertexSrc, fragmentSrc, bindings, &outcome.log, &outcome.failedStage)) {
         return outcome;
     }
@@ -227,73 +172,14 @@ ShaderCompileOutcome Shader::createEx(const std::string& vertexSrc,
     return outcome;
 }
 
-namespace {
-
-GfxUniformType shaderUniformTypeFromGL(GLenum type) {
-    switch (type) {
-    case GL_FLOAT:        return GfxUniformType::Float;
-    case GL_FLOAT_VEC2:   return GfxUniformType::Vec2;
-    case GL_FLOAT_VEC3:   return GfxUniformType::Vec3;
-    case GL_FLOAT_VEC4:   return GfxUniformType::Vec4;
-    case GL_INT:          return GfxUniformType::Int;
-    case GL_INT_VEC2:     return GfxUniformType::IVec2;
-    case GL_INT_VEC3:     return GfxUniformType::IVec3;
-    case GL_INT_VEC4:     return GfxUniformType::IVec4;
-    case GL_BOOL:         return GfxUniformType::Bool;
-    case GL_FLOAT_MAT2:   return GfxUniformType::Mat2;
-    case GL_FLOAT_MAT3:   return GfxUniformType::Mat3;
-    case GL_FLOAT_MAT4:   return GfxUniformType::Mat4;
-    case GL_SAMPLER_2D:   return GfxUniformType::Sampler2D;
-    case GL_SAMPLER_CUBE: return GfxUniformType::SamplerCube;
-    default:              return GfxUniformType::Unknown;
-    }
-}
-
-}  // namespace
-
 void Shader::reflectActiveUniforms() {
-    activeUniforms_.clear();
-    if (programId_ == 0) return;
-
-    GLint count = 0;
-    glGetProgramiv(programId_, GL_ACTIVE_UNIFORMS, &count);
-    if (count <= 0) return;
-
-    GLint maxNameLen = 0;
-    glGetProgramiv(programId_, GL_ACTIVE_UNIFORM_MAX_LENGTH, &maxNameLen);
-    if (maxNameLen <= 0) maxNameLen = 64;
-
-    std::string nameBuf(static_cast<size_t>(maxNameLen), '\0');
-    activeUniforms_.reserve(static_cast<size_t>(count));
-
-    for (GLint i = 0; i < count; ++i) {
-        GLsizei nameLen = 0;
-        GLint size = 0;
-        GLenum type = 0;
-        glGetActiveUniform(programId_, static_cast<GLuint>(i),
-                           static_cast<GLsizei>(maxNameLen), &nameLen,
-                           &size, &type, nameBuf.data());
-
-        std::string name(nameBuf.data(), static_cast<size_t>(nameLen));
-        // Strip "[0]" suffix so callers look up arrays by their declared name.
-        const auto bracket = name.find('[');
-        if (bracket != std::string::npos) {
-            name.erase(bracket);
-        }
-
-        GfxUniformInfo info;
-        info.type = shaderUniformTypeFromGL(type);
-        info.location = glGetUniformLocation(programId_, name.c_str());
-        info.arraySize = size > 0 ? static_cast<u32>(size) : 1u;
-        info.name = std::move(name);
-        activeUniforms_.push_back(std::move(info));
-    }
+    activeUniforms_ = device_->getActiveUniforms(programId_);
 }
 
 i32 Shader::getUniformLocation(const std::string& name) const {
     auto [it, inserted] = uniformCache_.emplace(name, -1);
     if (inserted) {
-        it->second = glGetUniformLocation(programId_, name.c_str());
+        it->second = device_->getUniformLocation(programId_, name.c_str());
         if (it->second < 0) {
             ES_LOG_WARN("Shader {}: uniform '{}' not found (typo or optimized out)",
                         programId_, name);
@@ -303,65 +189,65 @@ i32 Shader::getUniformLocation(const std::string& name) const {
 }
 
 void Shader::setUniform(const std::string& name, i32 value) const {
-    glUniform1i(getUniformLocation(name), value);
+    device_->setUniform1i(getUniformLocation(name), value);
 }
 
 void Shader::setUniform(const std::string& name, f32 value) const {
-    glUniform1f(getUniformLocation(name), value);
+    device_->setUniform1f(getUniformLocation(name), value);
 }
 
 void Shader::setUniform(const std::string& name, const glm::vec2& value) const {
-    glUniform2f(getUniformLocation(name), value.x, value.y);
+    device_->setUniform2f(getUniformLocation(name), value.x, value.y);
 }
 
 void Shader::setUniform(const std::string& name, const glm::vec3& value) const {
-    glUniform3f(getUniformLocation(name), value.x, value.y, value.z);
+    device_->setUniform3f(getUniformLocation(name), value.x, value.y, value.z);
 }
 
 void Shader::setUniform(const std::string& name, const glm::vec4& value) const {
-    glUniform4f(getUniformLocation(name), value.x, value.y, value.z, value.w);
+    device_->setUniform4f(getUniformLocation(name), value.x, value.y, value.z, value.w);
 }
 
 void Shader::setUniform(const std::string& name, const glm::mat3& value) const {
-    glUniformMatrix3fv(getUniformLocation(name), 1, GL_FALSE, glm::value_ptr(value));
+    device_->setUniformMat3(getUniformLocation(name), glm::value_ptr(value));
 }
 
 void Shader::setUniform(const std::string& name, const glm::mat4& value) const {
-    glUniformMatrix4fv(getUniformLocation(name), 1, GL_FALSE, glm::value_ptr(value));
+    device_->setUniformMat4(getUniformLocation(name), glm::value_ptr(value));
 }
 
 void Shader::setUniform(i32 location, i32 value) const {
-    if (location >= 0) glUniform1i(location, value);
+    device_->setUniform1i(location, value);
 }
 
 void Shader::setUniform(i32 location, f32 value) const {
-    if (location >= 0) glUniform1f(location, value);
+    device_->setUniform1f(location, value);
 }
 
 void Shader::setUniform(i32 location, const glm::vec2& value) const {
-    if (location >= 0) glUniform2f(location, value.x, value.y);
+    device_->setUniform2f(location, value.x, value.y);
 }
 
 void Shader::setUniform(i32 location, const glm::vec3& value) const {
-    if (location >= 0) glUniform3f(location, value.x, value.y, value.z);
+    device_->setUniform3f(location, value.x, value.y, value.z);
 }
 
 void Shader::setUniform(i32 location, const glm::vec4& value) const {
-    if (location >= 0) glUniform4f(location, value.x, value.y, value.z, value.w);
+    device_->setUniform4f(location, value.x, value.y, value.z, value.w);
 }
 
 void Shader::setUniform(i32 location, const glm::mat3& value) const {
-    if (location >= 0) glUniformMatrix3fv(location, 1, GL_FALSE, glm::value_ptr(value));
+    device_->setUniformMat3(location, glm::value_ptr(value));
 }
 
 void Shader::setUniform(i32 location, const glm::mat4& value) const {
-    if (location >= 0) glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(value));
+    device_->setUniformMat4(location, glm::value_ptr(value));
 }
 
 i32 Shader::getAttribLocation(const std::string& name) const {
     auto [it, inserted] = attribCache_.emplace(name, -1);
     if (inserted) {
-        it->second = glGetAttribLocation(programId_, name.c_str());
+        it->second = device_->getAttribLocation(programId_, name.c_str());
     }
     return it->second;
 }

--- a/src/esengine/renderer/Shader.hpp
+++ b/src/esengine/renderer/Shader.hpp
@@ -29,6 +29,8 @@
 
 namespace esengine {
 
+class GfxDevice;
+
 struct AttribBinding {
     u32 index;
     const char* name;
@@ -100,7 +102,7 @@ public:
      * @param fragmentSrc Fragment shader GLSL source
      * @return Unique pointer to the shader, or nullptr on failure
      */
-    static Unique<Shader> create(const std::string& vertexSrc, const std::string& fragmentSrc);
+    static Unique<Shader> create(GfxDevice& device, const std::string& vertexSrc, const std::string& fragmentSrc);
 
     /**
      * @brief Creates a shader with explicit attribute bindings applied before linking
@@ -109,7 +111,8 @@ public:
      * @param bindings Attribute location bindings
      * @return Unique pointer to the shader, or nullptr on failure
      */
-    static Unique<Shader> createWithBindings(const std::string& vertexSrc, const std::string& fragmentSrc,
+    static Unique<Shader> createWithBindings(GfxDevice& device,
+                                              const std::string& vertexSrc, const std::string& fragmentSrc,
                                               std::initializer_list<AttribBinding> bindings);
 
     /**
@@ -118,7 +121,8 @@ public:
      * @param fragmentPath Path to fragment shader file
      * @return Unique pointer to the shader, or nullptr on failure
      */
-    static Unique<Shader> createFromFile(const std::string& vertexPath, const std::string& fragmentPath);
+    static Unique<Shader> createFromFile(GfxDevice& device,
+                                         const std::string& vertexPath, const std::string& fragmentPath);
 
     /**
      * @brief Creates a shader and exposes the driver log on failure
@@ -127,7 +131,8 @@ public:
      * so callers (notably ShaderLoader) can remap the GL log back to the
      * original .esshader file and line numbers.
      */
-    static ShaderCompileOutcome createEx(const std::string& vertexSrc,
+    static ShaderCompileOutcome createEx(GfxDevice& device,
+                                         const std::string& vertexSrc,
                                          const std::string& fragmentSrc,
                                          std::initializer_list<AttribBinding> bindings = {});
 
@@ -212,6 +217,7 @@ private:
 
     void reflectActiveUniforms();
 
+    GfxDevice* device_ = nullptr;  ///< Set by the create* factories; all GL goes through it.
     u32 programId_ = 0;
 
     /** @brief Cached uniform locations (mutable for const uniform setters) */

--- a/src/esengine/renderer/StateTracker.cpp
+++ b/src/esengine/renderer/StateTracker.cpp
@@ -41,6 +41,14 @@ void StateTracker::reset() {
     current_program_ = 0;
     bound_textures_.fill(0);
 
+    // The actual VAO/buffer/framebuffer GL bindings are not forced here, so mark
+    // them unknown: the first bind of each per frame then always issues, which is
+    // correct regardless of leftover GL state and costs at most one bind/frame.
+    vao_bound_ = UNKNOWN_BINDING;
+    vertex_buffer_bound_ = UNKNOWN_BINDING;
+    index_buffer_bound_ = UNKNOWN_BINDING;
+    framebuffer_bound_ = UNKNOWN_BINDING;
+
     vp_x_ = -1;
     vp_y_ = -1;
     vp_w_ = 0;
@@ -124,6 +132,38 @@ void StateTracker::useProgram(u32 programId) {
     if (current_program_ == programId) return;
     current_program_ = programId;
     device_.useProgram(programId);
+}
+
+void StateTracker::bindVertexArray(u32 vaoId) {
+    if (vao_bound_ == vaoId) return;
+    vao_bound_ = vaoId;
+    device_.bindVertexArray(vaoId);
+    // The element-array (index) buffer binding is part of VAO state, so the
+    // freshly bound VAO now defines it — our cache no longer reflects reality.
+    index_buffer_bound_ = UNKNOWN_BINDING;
+}
+
+void StateTracker::bindVertexBuffer(u32 bufferId) {
+    if (vertex_buffer_bound_ == bufferId) return;
+    vertex_buffer_bound_ = bufferId;
+    device_.bindVertexBuffer(bufferId);
+}
+
+void StateTracker::bindIndexBuffer(u32 bufferId) {
+    if (index_buffer_bound_ == bufferId) return;
+    index_buffer_bound_ = bufferId;
+    device_.bindIndexBuffer(bufferId);
+}
+
+void StateTracker::bindFramebuffer(u32 fboId) {
+    if (framebuffer_bound_ == fboId) return;
+    framebuffer_bound_ = fboId;
+    device_.bindFramebuffer(fboId);
+}
+
+void StateTracker::invalidateBufferBindings() {
+    vertex_buffer_bound_ = UNKNOWN_BINDING;
+    index_buffer_bound_ = UNKNOWN_BINDING;
 }
 
 void StateTracker::setDepthTest(bool enabled) {

--- a/src/esengine/renderer/StateTracker.hpp
+++ b/src/esengine/renderer/StateTracker.hpp
@@ -31,6 +31,22 @@ public:
 
     void useProgram(u32 programId);
 
+    // -- Buffer / VAO / framebuffer binding (the binds resource classes used to
+    //    issue raw, silently desyncing this cache). Routing them here keeps the
+    //    cache authoritative for the whole engine.
+    void bindVertexArray(u32 vaoId);
+    void bindVertexBuffer(u32 bufferId);
+    void bindIndexBuffer(u32 bufferId);
+    void bindFramebuffer(u32 fboId);
+
+    /**
+     * @brief Drops the cached vertex/index buffer bindings.
+     * @details Use before re-issuing the explicit VBO+attrib+IBO rebind that
+     *          works around the WeChat WebGL VAO state-restoration bug, so the
+     *          rebinds are not deduped away.
+     */
+    void invalidateBufferBindings();
+
     void setDepthTest(bool enabled);
     void setDepthWrite(bool enabled);
 
@@ -62,6 +78,12 @@ private:
 
     u32 current_program_ = 0;
     std::array<u32, MAX_TEXTURE_SLOTS> bound_textures_{};
+
+    static constexpr u32 UNKNOWN_BINDING = 0xFFFFFFFFu;
+    u32 vao_bound_ = 0;
+    u32 vertex_buffer_bound_ = 0;
+    u32 index_buffer_bound_ = 0;
+    u32 framebuffer_bound_ = 0;
 
     i32 vp_x_ = -1, vp_y_ = -1;
     u32 vp_w_ = 0, vp_h_ = 0;

--- a/src/esengine/renderer/Texture.cpp
+++ b/src/esengine/renderer/Texture.cpp
@@ -1,7 +1,9 @@
 /**
  * @file    Texture.cpp
- * @brief   Texture implementation for OpenGL/WebGL
- * @details Implements texture creation, loading (via stb_image), and management.
+ * @brief   Texture implementation (device-backed)
+ * @details Thin RAII handle over a GPU texture. All GL is delegated to GfxDevice;
+ *          this file contains no GL calls and no platform ifdefs — textures work
+ *          on every platform the device backs (web and native alike).
  *
  * @author  ESEngine Team
  * @date    2026
@@ -11,68 +13,43 @@
  */
 
 #include "Texture.hpp"
+#include "GfxDevice.hpp"
 #include "../core/Log.hpp"
-#include "OpenGLHeaders.hpp"
-
-#include <span>
 
 #ifndef ES_PLATFORM_WEB
 #include <stb_image.h>
 #endif
 
+#include <span>
+
 namespace esengine {
 
 namespace {
 
-#ifdef ES_PLATFORM_WEB
-GLenum toGLFormat(TextureFormat format) {
+GfxPixelFormat toGfxPixelFormat(TextureFormat format) {
     switch (format) {
-    case TextureFormat::RGB8:    return GL_RGB;
-    case TextureFormat::RGBA8:   return GL_RGBA;
-    case TextureFormat::Depth24: return GL_DEPTH_COMPONENT;
-    default: return GL_RGBA;
+    case TextureFormat::RGB8:    return GfxPixelFormat::RGB8;
+    case TextureFormat::RGBA8:   return GfxPixelFormat::RGBA8;
+    case TextureFormat::Depth24: return GfxPixelFormat::DepthComponent24;
+    default:                     return GfxPixelFormat::RGBA8;
     }
 }
 
-GLenum toGLInternalFormat(TextureFormat format) {
-    switch (format) {
-    case TextureFormat::RGB8:    return GL_RGB8;
-    case TextureFormat::RGBA8:   return GL_RGBA8;
-    case TextureFormat::Depth24: return GL_DEPTH_COMPONENT24;
-    default: return GL_RGBA8;
-    }
+u32 bytesPerPixel(TextureFormat format) {
+    return format == TextureFormat::RGBA8 ? 4u : 3u;
 }
-
-GLenum toGLFilter(TextureFilter filter) {
-    switch (filter) {
-    case TextureFilter::Nearest: return GL_NEAREST;
-    case TextureFilter::Linear:  return GL_LINEAR;
-    default: return GL_LINEAR;
-    }
-}
-
-GLenum toGLWrap(TextureWrap wrap) {
-    switch (wrap) {
-    case TextureWrap::Repeat:         return GL_REPEAT;
-    case TextureWrap::ClampToEdge:    return GL_CLAMP_TO_EDGE;
-    case TextureWrap::MirroredRepeat: return GL_MIRRORED_REPEAT;
-    default: return GL_REPEAT;
-    }
-}
-#endif
 
 }  // namespace
 
 Texture::~Texture() {
-#ifdef ES_PLATFORM_WEB
-    if (textureId_ != 0) {
-        glDeleteTextures(1, &textureId_);
+    if (textureId_ != 0 && device_) {
+        device_->deleteTexture(textureId_);
     }
-#endif
 }
 
 Texture::Texture(Texture&& other) noexcept
-    : textureId_(other.textureId_)
+    : device_(other.device_)
+    , textureId_(other.textureId_)
     , width_(other.width_)
     , height_(other.height_)
     , format_(other.format_) {
@@ -84,11 +61,10 @@ Texture::Texture(Texture&& other) noexcept
 
 Texture& Texture::operator=(Texture&& other) noexcept {
     if (this != &other) {
-#ifdef ES_PLATFORM_WEB
-        if (textureId_ != 0) {
-            glDeleteTextures(1, &textureId_);
+        if (textureId_ != 0 && device_) {
+            device_->deleteTexture(textureId_);
         }
-#endif
+        device_ = other.device_;
         textureId_ = other.textureId_;
         width_ = other.width_;
         height_ = other.height_;
@@ -101,27 +77,28 @@ Texture& Texture::operator=(Texture&& other) noexcept {
     return *this;
 }
 
-Unique<Texture> Texture::create(const TextureSpecification& spec) {
+Unique<Texture> Texture::create(GfxDevice& device, const TextureSpecification& spec) {
     auto texture = makeUnique<Texture>();
+    texture->device_ = &device;
     if (!texture->initialize(spec)) {
         return nullptr;
     }
     return texture;
 }
 
-Unique<Texture> Texture::create(u32 width, u32 height, std::span<const u8> pixels,
+Unique<Texture> Texture::create(GfxDevice& device, u32 width, u32 height, std::span<const u8> pixels,
                                  TextureFormat format, bool flipY) {
-    [[maybe_unused]] u32 expectedSize = width * height * (format == TextureFormat::RGBA8 ? 4 : 3);
+    [[maybe_unused]] u32 expectedSize = width * height * bytesPerPixel(format);
     ES_ASSERT(pixels.size() == expectedSize, "Pixel data size mismatch");
-    return createRaw(width, height, pixels.data(), format, flipY);
+    return createRaw(device, width, height, pixels.data(), format, flipY);
 }
 
-Unique<Texture> Texture::create(u32 width, u32 height, const std::vector<u8>& pixels,
+Unique<Texture> Texture::create(GfxDevice& device, u32 width, u32 height, const std::vector<u8>& pixels,
                                  TextureFormat format, bool flipY) {
-    return create(width, height, std::span<const u8>(pixels), format, flipY);
+    return create(device, width, height, std::span<const u8>(pixels), format, flipY);
 }
 
-Unique<Texture> Texture::createRaw(u32 width, u32 height, const void* data,
+Unique<Texture> Texture::createRaw(GfxDevice& device, u32 width, u32 height, const void* data,
                                     TextureFormat format, bool flipY) {
     TextureSpecification spec;
     spec.width = width;
@@ -132,19 +109,20 @@ Unique<Texture> Texture::createRaw(u32 width, u32 height, const void* data,
     spec.generateMips = false;
 
     auto texture = makeUnique<Texture>();
+    texture->device_ = &device;
     if (!texture->initialize(spec)) {
         return nullptr;
     }
 
     if (data) {
-        texture->setDataRaw(data, width * height * (format == TextureFormat::RGBA8 ? 4 : 3), flipY);
+        texture->setDataRaw(data, width * height * bytesPerPixel(format), flipY);
     }
 
     return texture;
 }
 
 #ifndef ES_PLATFORM_WEB
-Unique<Texture> Texture::createFromFile(const std::string& path) {
+Unique<Texture> Texture::createFromFile(GfxDevice& device, const std::string& path) {
     int width, height, channels;
     unsigned char* data = stbi_load(path.c_str(), &width, &height, &channels, 0);
 
@@ -170,7 +148,7 @@ Unique<Texture> Texture::createFromFile(const std::string& path) {
         format = TextureFormat::RGBA8;
     }
 
-    auto texture = createRaw(static_cast<u32>(width), static_cast<u32>(height), data, format);
+    auto texture = createRaw(device, static_cast<u32>(width), static_cast<u32>(height), data, format);
     stbi_image_free(data);
 
     if (texture) {
@@ -181,8 +159,10 @@ Unique<Texture> Texture::createFromFile(const std::string& path) {
 }
 #endif
 
-Unique<Texture> Texture::createFromExternalId(u32 glTextureId, u32 width, u32 height, TextureFormat format) {
+Unique<Texture> Texture::createFromExternalId(GfxDevice& device, u32 glTextureId, u32 width, u32 height,
+                                              TextureFormat format) {
     auto texture = makeUnique<Texture>();
+    texture->device_ = &device;
     texture->textureId_ = glTextureId;
     texture->width_ = width;
     texture->height_ = height;
@@ -195,58 +175,28 @@ bool Texture::initialize(const TextureSpecification& spec) {
     height_ = spec.height;
     format_ = spec.format;
 
-#ifdef ES_PLATFORM_WEB
-    glGenTextures(1, &textureId_);
-    glBindTexture(GL_TEXTURE_2D, textureId_);
-
-    // Set texture parameters
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, toGLFilter(spec.minFilter));
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, toGLFilter(spec.magFilter));
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, toGLWrap(spec.wrapS));
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, toGLWrap(spec.wrapT));
-
-    // Allocate texture storage
-    glTexImage2D(
-        GL_TEXTURE_2D,
-        0,
-        toGLInternalFormat(spec.format),
-        width_,
-        height_,
-        0,
-        toGLFormat(spec.format),
-        GL_UNSIGNED_BYTE,
-        nullptr
-    );
+    textureId_ = device_->createTexture();
+    device_->texImage2D(textureId_, width_, height_, toGfxPixelFormat(spec.format), nullptr);
+    device_->setTextureParams(textureId_, spec.minFilter, spec.magFilter, spec.wrapS, spec.wrapT);
 
     if (spec.generateMips) {
-        glGenerateMipmap(GL_TEXTURE_2D);
+        device_->generateMipmaps(textureId_);
     }
 
     ES_LOG_DEBUG("Created texture {}x{} (ID: {})", width_, height_, textureId_);
     return true;
-#else
-    (void)spec;
-    return false;
-#endif
 }
 
 void Texture::bind(u32 slot) const {
-#ifdef ES_PLATFORM_WEB
-    glActiveTexture(GL_TEXTURE0 + slot);
-    glBindTexture(GL_TEXTURE_2D, textureId_);
-#else
-    (void)slot;
-#endif
+    if (device_) device_->bindTexture(slot, textureId_);
 }
 
 void Texture::unbind() const {
-#ifdef ES_PLATFORM_WEB
-    glBindTexture(GL_TEXTURE_2D, 0);
-#endif
+    if (device_) device_->bindTexture(0, 0);
 }
 
 void Texture::setData(std::span<const u8> pixels) {
-    [[maybe_unused]] u32 expectedSize = width_ * height_ * (format_ == TextureFormat::RGBA8 ? 4 : 3);
+    [[maybe_unused]] u32 expectedSize = width_ * height_ * bytesPerPixel(format_);
     ES_ASSERT(pixels.size() == expectedSize, "Pixel data size mismatch");
     setDataRaw(pixels.data(), static_cast<u32>(pixels.size()));
 }
@@ -256,32 +206,13 @@ void Texture::setData(const std::vector<u8>& pixels) {
 }
 
 void Texture::setDataRaw(const void* data, u32 sizeBytes, bool flipY) {
-#ifdef ES_PLATFORM_WEB
-    [[maybe_unused]] u32 bpp = (format_ == TextureFormat::RGBA8) ? 4 : 3;
+    [[maybe_unused]] u32 bpp = bytesPerPixel(format_);
     ES_ASSERT(sizeBytes == width_ * height_ * bpp, "Data size mismatch");
     (void)sizeBytes;
 
-    glBindTexture(GL_TEXTURE_2D, textureId_);
-    if (flipY) {
-        glPixelStorei(0x9240 /* GL_UNPACK_FLIP_Y_WEBGL */, GL_TRUE);
-    }
-    glTexSubImage2D(
-        GL_TEXTURE_2D,
-        0,
-        0, 0,
-        width_, height_,
-        toGLFormat(format_),
-        GL_UNSIGNED_BYTE,
-        data
-    );
-    if (flipY) {
-        glPixelStorei(0x9240, GL_FALSE);
-    }
-#else
-    (void)data;
-    (void)sizeBytes;
-    (void)flipY;
-#endif
+    if (flipY) device_->setUnpackFlipY(true);
+    device_->texSubImage2D(textureId_, 0, 0, width_, height_, toGfxPixelFormat(format_), data);
+    if (flipY) device_->setUnpackFlipY(false);
 }
 
 }  // namespace esengine

--- a/src/esengine/renderer/Texture.hpp
+++ b/src/esengine/renderer/Texture.hpp
@@ -26,6 +26,8 @@
 
 namespace esengine {
 
+class GfxDevice;
+
 // =============================================================================
 // Texture Enums
 // =============================================================================
@@ -145,7 +147,7 @@ public:
      * @details Creates a texture with uninitialized pixel data.
      *          Use setData() to upload pixels later.
      */
-    static Unique<Texture> create(const TextureSpecification& spec);
+    static Unique<Texture> create(GfxDevice& device, const TextureSpecification& spec);
 
     /**
      * @brief Creates a texture from a span of pixel data
@@ -155,7 +157,7 @@ public:
      * @param format Pixel format (default RGBA8)
      * @return Unique pointer to the texture
      */
-    static Unique<Texture> create(u32 width, u32 height, std::span<const u8> pixels,
+    static Unique<Texture> create(GfxDevice& device, u32 width, u32 height, std::span<const u8> pixels,
                                    TextureFormat format = TextureFormat::RGBA8,
                                    bool flipY = false);
 
@@ -168,7 +170,7 @@ public:
      * @param flipY Flip vertically on upload (for web image data)
      * @return Unique pointer to the texture
      */
-    static Unique<Texture> create(u32 width, u32 height, const std::vector<u8>& pixels,
+    static Unique<Texture> create(GfxDevice& device, u32 width, u32 height, const std::vector<u8>& pixels,
                                    TextureFormat format = TextureFormat::RGBA8,
                                    bool flipY = false);
 
@@ -180,7 +182,7 @@ public:
      * @note Supported formats depend on the image loading implementation.
      */
 #ifndef ES_PLATFORM_WEB
-    static Unique<Texture> createFromFile(const std::string& path);
+    static Unique<Texture> createFromFile(GfxDevice& device, const std::string& path);
 #endif
 
     // =========================================================================
@@ -245,7 +247,7 @@ public:
      * @param format Pixel format (default RGBA8)
      * @return Unique pointer to the texture
      */
-    static Unique<Texture> createRaw(u32 width, u32 height, const void* data,
+    static Unique<Texture> createRaw(GfxDevice& device, u32 width, u32 height, const void* data,
                                       TextureFormat format = TextureFormat::RGBA8,
                                       bool flipY = false);
 
@@ -257,7 +259,7 @@ public:
      * @param format Pixel format
      * @return Unique pointer to the texture wrapper
      */
-    static Unique<Texture> createFromExternalId(u32 glTextureId, u32 width, u32 height,
+    static Unique<Texture> createFromExternalId(GfxDevice& device, u32 glTextureId, u32 width, u32 height,
                                                  TextureFormat format = TextureFormat::RGBA8);
 
     /**
@@ -275,6 +277,7 @@ private:
      */
     bool initialize(const TextureSpecification& spec);
 
+    GfxDevice* device_ = nullptr;  ///< Set by the create* factories; all GL goes through it.
     u32 textureId_ = 0;
     u32 width_ = 0;
     u32 height_ = 0;

--- a/src/esengine/resource/ResourceManager.cpp
+++ b/src/esengine/resource/ResourceManager.cpp
@@ -19,17 +19,20 @@
 #endif
 #include "../core/Log.hpp"
 #include "../platform/PathResolver.hpp"
+#include "../renderer/GfxDevice.hpp"
 #include "../renderer/Shader.hpp"
 #include "../renderer/Texture.hpp"
 #include "../renderer/Buffer.hpp"
 
 namespace esengine::resource {
 
-void ResourceManager::init() {
+void ResourceManager::init(GfxDevice& device) {
     if (initialized_) {
         ES_LOG_WARN("ResourceManager already initialized");
         return;
     }
+
+    device_ = &device;
 
 #ifndef ES_PLATFORM_WEB
     stbi_set_flip_vertically_on_load(true);
@@ -78,7 +81,7 @@ void ResourceManager::update() {
 // =============================================================================
 
 ShaderHandle ResourceManager::createShader(const std::string& vertSrc, const std::string& fragSrc) {
-    auto shader = Shader::create(vertSrc, fragSrc);
+    auto shader = Shader::create(*device_, vertSrc, fragSrc);
     if (!shader) {
         ES_LOG_ERROR("Failed to create shader from source");
         return ShaderHandle();
@@ -88,7 +91,7 @@ ShaderHandle ResourceManager::createShader(const std::string& vertSrc, const std
 
 ShaderHandle ResourceManager::createShaderWithBindings(const std::string& vertSrc, const std::string& fragSrc,
                                                         std::initializer_list<AttribBinding> bindings) {
-    auto shader = Shader::createWithBindings(vertSrc, fragSrc, bindings);
+    auto shader = Shader::createWithBindings(*device_, vertSrc, fragSrc, bindings);
     if (!shader) {
         ES_LOG_ERROR("Failed to create shader with bindings from source");
         return ShaderHandle();
@@ -109,7 +112,7 @@ ShaderHandle ResourceManager::loadShader(const std::string& vertPath, const std:
     }
 
     // Load from files
-    auto shader = Shader::createFromFile(vertPath, fragPath);
+    auto shader = Shader::createFromFile(*device_, vertPath, fragPath);
     if (!shader) {
         stats_.cacheMisses++;
         return ShaderHandle();
@@ -128,7 +131,7 @@ ShaderHandle ResourceManager::loadShaderFile(const std::string& path, const std:
         return cached;
     }
 
-    ShaderFileLoader loader;
+    ShaderFileLoader loader(*device_);
     LoadRequest request;
     request.path = path;
     request.platform = platform;
@@ -164,7 +167,7 @@ ShaderHandle ResourceManager::loadEngineShader(const std::string& name, const st
 
     std::string path = PathResolver::editorPath("src/esengine/data/shaders/" + name + ".esshader");
 
-    ShaderFileLoader loader;
+    ShaderFileLoader loader(*device_);
     LoadRequest request;
     request.path = path;
     request.platform = platform;
@@ -203,7 +206,7 @@ u32 ResourceManager::getShaderRefCount(ShaderHandle handle) const {
 // =============================================================================
 
 TextureHandle ResourceManager::createTexture(const TextureSpecification& spec) {
-    auto texture = Texture::create(spec);
+    auto texture = Texture::create(*device_, spec);
     if (!texture) {
         ES_LOG_ERROR("Failed to create texture from spec");
         return TextureHandle();
@@ -214,7 +217,7 @@ TextureHandle ResourceManager::createTexture(const TextureSpecification& spec) {
 TextureHandle ResourceManager::createTexture(u32 width, u32 height, ConstSpan<u8> pixels,
                                               TextureFormat format, bool flipY) {
     std::vector<u8> pixelVec(pixels.begin(), pixels.end());
-    auto texture = Texture::create(width, height, pixelVec, format, flipY);
+    auto texture = Texture::create(*device_, width, height, pixelVec, format, flipY);
     if (!texture) {
         ES_LOG_ERROR("Failed to create texture from pixels");
         return TextureHandle();
@@ -235,7 +238,7 @@ TextureHandle ResourceManager::loadTexture(const std::string& path) {
     stats_.cacheMisses++;
     return TextureHandle();
 #else
-    auto texture = Texture::createFromFile(path);
+    auto texture = Texture::createFromFile(*device_, path);
     if (!texture) {
         stats_.cacheMisses++;
         return TextureHandle();
@@ -295,7 +298,7 @@ u32 ResourceManager::getTextureRefCount(TextureHandle handle) const {
 }
 
 TextureHandle ResourceManager::registerExternalTexture(u32 glTextureId, u32 width, u32 height) {
-    auto texture = Texture::createFromExternalId(glTextureId, width, height, TextureFormat::RGBA8);
+    auto texture = Texture::createFromExternalId(*device_, glTextureId, width, height, TextureFormat::RGBA8);
     if (!texture) {
         ES_LOG_ERROR("Failed to register external texture (GL ID: {})", glTextureId);
         return TextureHandle();
@@ -549,7 +552,7 @@ void ResourceManager::reloadShader(ShaderHandle handle, const std::string& path)
 
     ES_LOG_INFO("HotReload: Reloading shader '{}'", path);
 
-    ShaderFileLoader loader;
+    ShaderFileLoader loader(*device_);
     LoadRequest request;
     request.path = path;
     auto result = loader.load(request);

--- a/src/esengine/resource/ResourceManager.hpp
+++ b/src/esengine/resource/ResourceManager.hpp
@@ -34,6 +34,8 @@
 #include <string>
 #include <unordered_map>
 
+namespace esengine { class GfxDevice; }
+
 namespace esengine::resource {
 
 // =============================================================================
@@ -96,8 +98,12 @@ public:
 
     /**
      * @brief Initializes the resource manager
+     * @param device The graphics device used to create all GPU resources
+     *        (shaders, textures, buffers). ResourceManager is the GPU-resource
+     *        factory, so it owns the single device reference the resource classes
+     *        route through.
      */
-    void init();
+    void init(GfxDevice& device);
 
     /**
      * @brief Shuts down and releases all resources
@@ -498,6 +504,7 @@ private:
 #endif
     LoaderRegistry loaderRegistry_;
     mutable ResourceStats stats_;
+    GfxDevice* device_ = nullptr;  ///< GPU device for resource creation (set in init)
     bool initialized_ = false;
 };
 

--- a/src/esengine/resource/loaders/ShaderLoader.cpp
+++ b/src/esengine/resource/loaders/ShaderLoader.cpp
@@ -103,7 +103,7 @@ LoadResult<Shader> ShaderFileLoader::loadFromSource(const std::string& source,
         return LoadResult<Shader>::err("Failed to assemble fragment shader");
     }
 
-    auto outcome = Shader::createEx(vertexAssembled.source, fragmentAssembled.source);
+    auto outcome = Shader::createEx(device_, vertexAssembled.source, fragmentAssembled.source);
     if (!outcome.shader || !outcome.shader->isValid()) {
         std::string remapped = outcome.log;
         const char* stageLabel = "unknown";

--- a/src/esengine/resource/loaders/ShaderLoader.hpp
+++ b/src/esengine/resource/loaders/ShaderLoader.hpp
@@ -22,6 +22,8 @@
 
 #include <string>
 
+namespace esengine { class GfxDevice; }
+
 namespace esengine::resource {
 
 // =============================================================================
@@ -50,6 +52,12 @@ using ShaderLoadResult = LoadResult<Shader>;
  */
 class ShaderFileLoader : public ResourceLoader<Shader> {
 public:
+    /**
+     * @brief Constructs the loader bound to a graphics device.
+     * @param device Device used to compile/link the shader program.
+     */
+    explicit ShaderFileLoader(GfxDevice& device) : device_(device) {}
+
     bool canLoad(const std::string& path) const override;
     std::vector<std::string> getSupportedExtensions() const override;
     LoadResult<Shader> load(const LoadRequest& request) override;
@@ -80,6 +88,9 @@ public:
      * @return Platform string (e.g., "WEBGL", "DESKTOP")
      */
     static std::string getDefaultPlatform();
+
+private:
+    GfxDevice& device_;
 };
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,3 +44,41 @@ add_executable(test_resource_pool
 )
 target_link_libraries(test_resource_pool PRIVATE esengine)
 add_test(NAME test_resource_pool COMMAND test_resource_pool)
+
+# Renderer GPU state-cache tests.
+# Compiles StateTracker.cpp directly against a MockGfxDevice — no GL/engine link,
+# so it runs on any C++20 toolchain (CI doesn't need emsdk for this).
+add_executable(test_state_tracker
+    renderer/test_state_tracker.cpp
+    ${CMAKE_SOURCE_DIR}/src/esengine/renderer/StateTracker.cpp
+)
+target_include_directories(test_state_tracker PRIVATE ${CMAKE_SOURCE_DIR}/src)
+add_test(NAME test_state_tracker COMMAND test_state_tracker)
+
+# Shader-vs-device decoupling: compiles the converted Shader.cpp against a
+# MockGfxDevice. Linking proves Shader contains no GL; asserts confirm it routes
+# create/uniform/reflect/delete through GfxDevice.
+add_executable(test_shader_device
+    renderer/test_shader_device.cpp
+    ${CMAKE_SOURCE_DIR}/src/esengine/renderer/Shader.cpp
+    ${CMAKE_SOURCE_DIR}/src/esengine/core/Log.cpp
+)
+target_include_directories(test_shader_device PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/third_party/glm
+)
+add_test(NAME test_shader_device COMMAND test_shader_device)
+
+# Texture + Framebuffer decoupling: compiles the converted classes against a
+# MockGfxDevice. The harness stubs the (uncalled) stb file loader.
+add_executable(test_texture_fb
+    renderer/test_texture_fb.cpp
+    ${CMAKE_SOURCE_DIR}/src/esengine/renderer/Texture.cpp
+    ${CMAKE_SOURCE_DIR}/src/esengine/renderer/Framebuffer.cpp
+    ${CMAKE_SOURCE_DIR}/src/esengine/core/Log.cpp
+)
+target_include_directories(test_texture_fb PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/third_party/stb
+)
+add_test(NAME test_texture_fb COMMAND test_texture_fb)

--- a/tests/renderer/MockGfxDevice.hpp
+++ b/tests/renderer/MockGfxDevice.hpp
@@ -1,0 +1,129 @@
+// Shared test double for the renderer GPU abstraction (RC5-GfxDevice).
+//
+// Records the device calls the renderer harnesses assert on; every other method
+// is a no-op stub. Implementing the full GfxDevice contract here also proves the
+// interface stays self-consistent as it evolves.
+#pragma once
+
+#include "esengine/renderer/GfxDevice.hpp"
+
+#include <vector>
+
+namespace esengine {
+
+struct MockGfxDevice final : GfxDevice {
+    // call counters
+    int useProgramCalls = 0;
+    int bindTextureCalls = 0;
+    int bindVertexArrayCalls = 0;
+    int bindVertexBufferCalls = 0;
+    int bindIndexBufferCalls = 0;
+    int bindFramebufferCalls = 0;
+    int createProgramCalls = 0;
+    int deleteProgramCalls = 0;
+    int setUniform1iCalls = 0;
+    int setUniform4fCalls = 0;
+    int getActiveUniformsCalls = 0;
+    int createTextureCalls = 0;
+    int deleteTextureCalls = 0;
+    int texImage2DCalls = 0;
+    int texSubImage2DCalls = 0;
+    int setTextureParamsCalls = 0;
+    int generateMipmapsCalls = 0;
+    u32 nextTextureId = 100;
+    u32 lastDeletedTexture = 0;
+    int createFramebufferCalls = 0;
+    int deleteFramebufferCalls = 0;
+    int framebufferTexture2DCalls = 0;
+    u32 nextFramebufferId = 500;
+    // last args
+    u32 lastProgram = 0, lastVao = 0, lastVbo = 0, lastIbo = 0, lastFbo = 0;
+    i32 lastUniform1iLoc = -999, lastUniform1iVal = 0;
+
+    void init() override {}
+    void shutdown() override {}
+
+    void setViewport(i32, i32, u32, u32) override {}
+    void setClearColor(f32, f32, f32, f32) override {}
+    void setClearStencil(i32) override {}
+    void clear(bool, bool, bool) override {}
+
+    void setBlendEnabled(bool) override {}
+    void setBlendMode(BlendMode) override {}
+
+    void setDepthTest(bool) override {}
+    void setDepthWrite(bool) override {}
+
+    void setStencilTest(bool) override {}
+    void setStencilFunc(GfxStencilFunc, i32, u32) override {}
+    void setStencilOp(GfxStencilOp, GfxStencilOp, GfxStencilOp) override {}
+    void setStencilMask(u32) override {}
+    void setColorMask(bool, bool, bool, bool) override {}
+
+    void setScissorTest(bool) override {}
+    void setScissor(i32, i32, i32, i32) override {}
+
+    void setCulling(bool) override {}
+    void setCullFace(bool) override {}
+
+    void bindTexture(u32, u32 textureId) override { ++bindTextureCalls; (void)textureId; }
+
+    u32 createProgram(const char*, const char*, const GfxAttribBinding*, u32,
+                      std::string*, GfxShaderStage* stage) override {
+        ++createProgramCalls;
+        if (stage) *stage = GfxShaderStage::None;
+        return 1;  // pretend link succeeds, program id 1
+    }
+    void deleteProgram(u32) override { ++deleteProgramCalls; }
+    void useProgram(u32 programId) override { ++useProgramCalls; lastProgram = programId; }
+    i32 getUniformLocation(u32, const char*) override { return 0; }
+    i32 getAttribLocation(u32, const char*) override { return 0; }
+    void setUniform1i(i32 loc, i32 v) override { ++setUniform1iCalls; lastUniform1iLoc = loc; lastUniform1iVal = v; }
+    void setUniform1f(i32, f32) override {}
+    void setUniform2f(i32, f32, f32) override {}
+    void setUniform3f(i32, f32, f32, f32) override {}
+    void setUniform4f(i32, f32, f32, f32, f32) override { ++setUniform4fCalls; }
+    void setUniformMat3(i32, const f32*) override {}
+    void setUniformMat4(i32, const f32*) override {}
+    std::vector<GfxUniformInfo> getActiveUniforms(u32) override { ++getActiveUniformsCalls; return {}; }
+
+    u32 createBuffer() override { return 0; }
+    void deleteBuffer(u32) override {}
+    void bindVertexBuffer(u32 bufferId) override { ++bindVertexBufferCalls; lastVbo = bufferId; }
+    void bindIndexBuffer(u32 bufferId) override { ++bindIndexBufferCalls; lastIbo = bufferId; }
+    void bufferData(GfxBufferTarget, const void*, u32, bool) override {}
+    void bufferSubData(GfxBufferTarget, u32, const void*, u32) override {}
+
+    u32 createVertexArray() override { return 0; }
+    void deleteVertexArray(u32) override {}
+    void bindVertexArray(u32 vaoId) override { ++bindVertexArrayCalls; lastVao = vaoId; }
+    void enableVertexAttrib(u32) override {}
+    void vertexAttribPointer(u32, i32, GfxDataType, bool, i32, u32) override {}
+    void vertexAttribDivisor(u32, u32) override {}
+
+    void drawElements(u32, GfxDataType, u32) override {}
+    void drawArrays(u32, u32) override {}
+    void drawElementsInstanced(u32, GfxDataType, u32, u32) override {}
+
+    u32 createTexture() override { ++createTextureCalls; return nextTextureId++; }
+    void deleteTexture(u32 id) override { ++deleteTextureCalls; lastDeletedTexture = id; }
+    void texImage2D(u32, u32, u32, GfxPixelFormat, const void*) override { ++texImage2DCalls; }
+    void texSubImage2D(u32, i32, i32, u32, u32, GfxPixelFormat, const void*) override { ++texSubImage2DCalls; }
+    void setTextureParams(u32, TextureFilter, TextureFilter, TextureWrap, TextureWrap) override { ++setTextureParamsCalls; }
+    void generateMipmaps(u32) override { ++generateMipmapsCalls; }
+    void pixelStorei(u32, i32) override {}
+    void setUnpackFlipY(bool) override {}
+
+    u32 createFramebuffer() override { ++createFramebufferCalls; return nextFramebufferId++; }
+    void deleteFramebuffer(u32) override { ++deleteFramebufferCalls; }
+    void bindFramebuffer(u32 fboId) override { ++bindFramebufferCalls; lastFbo = fboId; }
+    void framebufferTexture2D(u32, GfxAttachment, u32) override { ++framebufferTexture2DCalls; }
+    bool checkFramebufferStatus() override { return true; }
+
+    void readPixels(i32, i32, u32, u32, GfxPixelFormat, void*) override {}
+
+    void setWireframe(bool) override {}
+    u32 getError() override { return 0; }
+};
+
+}  // namespace esengine

--- a/tests/renderer/test_shader_device.cpp
+++ b/tests/renderer/test_shader_device.cpp
@@ -1,0 +1,54 @@
+// Native MSVC/CTest harness for Shader (RC5-GfxDevice).
+//
+// Compiles the CONVERTED Shader.cpp against MockGfxDevice. The fact this links at
+// all proves Shader no longer touches GL (it includes no GL headers); the asserts
+// confirm it routes create/uniform/reflect/delete through GfxDevice.
+
+#include "MockGfxDevice.hpp"
+#include "esengine/renderer/Shader.hpp"
+
+#include <cstdio>
+
+using namespace esengine;
+
+static int g_failures = 0;
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) { std::printf("FAIL: %s\n", msg); ++g_failures; }          \
+        else { std::printf("ok:   %s\n", msg); }                                \
+    } while (0)
+
+int main() {
+    MockGfxDevice d;
+
+    {
+        auto shader = Shader::create(d, "vs", "fs");
+        CHECK(shader != nullptr, "Shader::create returns a shader on link success");
+        CHECK(d.createProgramCalls == 1, "create routes compile/link through device.createProgram");
+        CHECK(shader->isValid(), "shader is valid (programId from device)");
+        CHECK(shader->getProgramId() == 1, "programId is the device-returned id");
+        CHECK(d.getActiveUniformsCalls == 1, "reflection routes through device.getActiveUniforms");
+
+        shader->setUniform("u_tex", 3);
+        CHECK(d.setUniform1iCalls == 1, "setUniform(name,int) routes through device.setUniform1i");
+        CHECK(d.lastUniform1iVal == 3, "uniform value forwarded");
+
+        shader->setUniform("u_color", glm::vec4(1, 0, 0, 1));
+        CHECK(d.setUniform4fCalls == 1, "setUniform(name,vec4) routes through device.setUniform4f");
+
+        shader->bind();
+        CHECK(d.useProgramCalls == 1 && d.lastProgram == 1, "bind routes through device.useProgram");
+        shader->unbind();
+        CHECK(d.useProgramCalls == 2 && d.lastProgram == 0, "unbind routes through device.useProgram(0)");
+
+        // shader destructed at scope end -> device.deleteProgram
+    }
+    CHECK(d.deleteProgramCalls == 1, "destructor routes through device.deleteProgram");
+
+    if (g_failures == 0) {
+        std::printf("\nALL SHADER DEVICE TESTS PASSED\n");
+        return 0;
+    }
+    std::printf("\n%d FAILURE(S)\n", g_failures);
+    return 1;
+}

--- a/tests/renderer/test_state_tracker.cpp
+++ b/tests/renderer/test_state_tracker.cpp
@@ -1,0 +1,95 @@
+// Native MSVC/CTest harness for StateTracker (RC5-GfxDevice).
+//
+// Compiles StateTracker.cpp against MockGfxDevice — no GL, no glm. Verifies the
+// bind-dedup cache (program/texture/VAO/VBO/IBO/FBO) that makes StateTracker the
+// single authoritative GPU-state cache.
+
+#include "MockGfxDevice.hpp"
+#include "esengine/renderer/StateTracker.hpp"
+
+#include <cstdio>
+
+using namespace esengine;
+
+static int g_failures = 0;
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) { std::printf("FAIL: %s\n", msg); ++g_failures; }          \
+        else { std::printf("ok:   %s\n", msg); }                                \
+    } while (0)
+
+int main() {
+    // --- program dedup ---
+    {
+        MockGfxDevice d;
+        StateTracker s(d);
+        s.init();
+        s.useProgram(7);
+        s.useProgram(7);
+        s.useProgram(9);
+        CHECK(d.useProgramCalls == 2, "useProgram dedups repeats (7,7,9 -> 2 calls)");
+    }
+
+    // --- VAO dedup + IBO invalidation on VAO bind ---
+    {
+        MockGfxDevice d;
+        StateTracker s(d);
+        s.init();
+        s.bindVertexArray(5);
+        s.bindVertexArray(5);          // deduped
+        CHECK(d.bindVertexArrayCalls == 1, "bindVertexArray dedups repeats");
+
+        s.bindIndexBuffer(7);          // VAO bind invalidated ibo cache -> issues
+        s.bindIndexBuffer(7);          // now cached -> deduped
+        CHECK(d.bindIndexBufferCalls == 1, "bindIndexBuffer dedups after first bind");
+
+        s.bindVertexArray(6);          // new VAO -> ibo cache invalidated again
+        s.bindIndexBuffer(7);          // must re-issue: VAO carries its own element binding
+        CHECK(d.bindIndexBufferCalls == 2, "VAO rebind re-issues index buffer (element binding is VAO state)");
+        CHECK(d.bindVertexArrayCalls == 2, "second distinct VAO issues");
+    }
+
+    // --- VBO dedup is global (not VAO state) + invalidate forces rebind ---
+    {
+        MockGfxDevice d;
+        StateTracker s(d);
+        s.init();
+        s.bindVertexBuffer(3);
+        s.bindVertexBuffer(3);         // deduped
+        CHECK(d.bindVertexBufferCalls == 1, "bindVertexBuffer dedups repeats");
+
+        s.invalidateBufferBindings();  // WeChat VAO workaround path
+        s.bindVertexBuffer(3);         // forced through
+        CHECK(d.bindVertexBufferCalls == 2, "invalidateBufferBindings forces VBO rebind");
+    }
+
+    // --- framebuffer dedup ---
+    {
+        MockGfxDevice d;
+        StateTracker s(d);
+        s.init();
+        s.bindFramebuffer(2);
+        s.bindFramebuffer(2);
+        s.bindFramebuffer(0);
+        CHECK(d.bindFramebufferCalls == 2, "bindFramebuffer dedups repeats (2,2,0 -> 2 calls)");
+    }
+
+    // --- reset() marks bindings unknown so first bind per frame always issues ---
+    {
+        MockGfxDevice d;
+        StateTracker s(d);
+        s.init();
+        s.bindVertexArray(5);
+        CHECK(d.bindVertexArrayCalls == 1, "initial VAO bind issues");
+        s.reset();
+        s.bindVertexArray(5);          // same id, but reset marked unknown -> re-issues
+        CHECK(d.bindVertexArrayCalls == 2, "reset() forces re-issue of same VAO id");
+    }
+
+    if (g_failures == 0) {
+        std::printf("\nALL STATE TRACKER TESTS PASSED\n");
+        return 0;
+    }
+    std::printf("\n%d FAILURE(S)\n", g_failures);
+    return 1;
+}

--- a/tests/renderer/test_texture_fb.cpp
+++ b/tests/renderer/test_texture_fb.cpp
@@ -1,0 +1,86 @@
+// Native MSVC/CTest harness for Texture + Framebuffer (RC5-GfxDevice).
+//
+// Compiles the CONVERTED Texture.cpp and Framebuffer.cpp against MockGfxDevice.
+// Linking proves they no longer touch GL; the asserts confirm create/upload/
+// attach/delete all route through GfxDevice.
+
+#include "MockGfxDevice.hpp"
+#include "esengine/renderer/Texture.hpp"
+#include "esengine/renderer/Framebuffer.hpp"
+
+#include <cstdio>
+#include <vector>
+
+using namespace esengine;
+
+// Texture::createFromFile (native-only) references stb's file loader, which the
+// engine's stb impl compiles out (STBI_NO_STDIO). We never call createFromFile in
+// this harness, so stub the symbols to satisfy the linker without the decoder.
+extern "C" {
+    unsigned char* stbi_load(char const*, int*, int*, int*, int) { return nullptr; }
+    void stbi_image_free(void*) {}
+    char const* stbi_failure_reason() { return "stub"; }
+}
+
+static int g_failures = 0;
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) { std::printf("FAIL: %s\n", msg); ++g_failures; }          \
+        else { std::printf("ok:   %s\n", msg); }                                \
+    } while (0)
+
+int main() {
+    // --- Texture: empty spec with mips ---
+    {
+        MockGfxDevice d;
+        TextureSpecification spec;
+        spec.width = 8; spec.height = 8; spec.format = TextureFormat::RGBA8; spec.generateMips = true;
+        {
+            auto tex = Texture::create(d, spec);
+            CHECK(tex != nullptr, "Texture::create returns a texture");
+            CHECK(d.createTextureCalls == 1, "create routes through device.createTexture");
+            CHECK(d.texImage2DCalls == 1, "create allocates via device.texImage2D");
+            CHECK(d.setTextureParamsCalls == 1, "create sets params via device.setTextureParams");
+            CHECK(d.generateMipmapsCalls == 1, "generateMips routes through device.generateMipmaps");
+            CHECK(tex->getId() == 100, "texture id is device-assigned");
+            tex->bind(2);
+            CHECK(d.bindTextureCalls == 1, "bind routes through device.bindTexture");
+        }
+        CHECK(d.deleteTextureCalls == 1 && d.lastDeletedTexture == 100,
+              "destructor routes through device.deleteTexture");
+    }
+
+    // --- Texture: pixel upload ---
+    {
+        MockGfxDevice d;
+        std::vector<u8> pixels(2 * 2 * 4, 0xFF);
+        auto tex = Texture::create(d, 2, 2, pixels, TextureFormat::RGBA8, /*flipY*/ true);
+        CHECK(tex != nullptr, "Texture::create(pixels) returns a texture");
+        CHECK(d.texSubImage2DCalls == 1, "pixel upload routes through device.texSubImage2D");
+    }
+
+    // --- Framebuffer: color + depth-stencil ---
+    {
+        MockGfxDevice d;
+        FramebufferSpec spec;
+        spec.width = 64; spec.height = 64; spec.depthStencil = true;
+        {
+            auto fbo = Framebuffer::create(d, spec);
+            CHECK(fbo != nullptr, "Framebuffer::create returns a framebuffer");
+            CHECK(d.createFramebufferCalls == 1, "create routes through device.createFramebuffer");
+            CHECK(d.createTextureCalls == 2, "color + depth attachments via device.createTexture");
+            CHECK(d.framebufferTexture2DCalls == 2, "both attachments via device.framebufferTexture2D");
+            fbo->bind();
+            CHECK(d.bindFramebufferCalls >= 1, "bind routes through device.bindFramebuffer");
+        }
+        CHECK(d.deleteFramebufferCalls == 1, "destructor deletes the framebuffer via device");
+        CHECK(d.deleteTextureCalls == 2, "destructor deletes both attachments via device");
+    }
+
+    if (g_failures == 0) {
+        std::printf("\nALL TEXTURE/FRAMEBUFFER TESTS PASSED\n");
+        return 0;
+    }
+    std::printf("\n%d FAILURE(S)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## What

RC5 step toward **"GfxDevice as the sole GPU entry"** (see `docs/REARCHITECTURE.md`). The renderer had two parallel ways to reach the GPU: through `GfxDevice`/`StateTracker`, and raw `glXxx` inside the resource classes — the latter bypassed the device and silently desynced `StateTracker`'s cache (e.g. a `Shader::bind()` could leave the tracker thinking a different program was bound, so a later cache hit would skip the real bind → wrong shader, silently).

This collapses that onto **one device boundary + one state cache**.

## Changes

- **GfxDevice**: add `createProgram`/`deleteProgram`/`getAttribLocation`/`setClearStencil`/`setUnpackFlipY` and `Depth24Stencil8` / `DepthStencil` enums. `GLDevice` implements them — the multi-step shader compile/link protocol moves out of `Shader.cpp` into `GLDevice`, so the WebGL-only constants live in the one GL file.
- **StateTracker**: now caches VAO / VBO / IBO / framebuffer binds (was program/texture/render-state only) and is promoted to a **per-App service** so every renderer subsystem shares one authoritative cache.
- **Shader / Texture / Framebuffer**: thin RAII handles over `GfxDevice` with **zero raw gl and zero GL includes**. `Texture` drops its `ES_PLATFORM_WEB`-only bodies, so **native textures work again** instead of being dead.
- **ResourceManager** now holds the `GfxDevice&` (it is the GPU-resource factory); `EstellaContext` creates `GLDevice` before it. `RenderTarget`/`RenderTargetManager` thread the device through to `Framebuffer`.

## Verification

No emsdk locally, so the production web build is validated in CI. Locally, the converted resource classes are compiled against a new `tests/renderer/MockGfxDevice.hpp` — **linking proves they no longer touch GL** — plus three native CTest harnesses (`state_tracker`, `shader_device`, `texture_fb`, all green) that need no GL/emsdk and run in CI.

Raw `gl*` outside `GLDevice`: **135 → 41** (Shader/Texture/Framebuffer eliminated).

## Follow-up (separate PR)

Convert `Buffer`/`VertexArray` + `CustomGeometry`; retire `Renderer`/`BatchRenderer2D` and rebase `ImmediateDraw` on `TransientBufferPool`; then a CI guard that fails the build on any `gl*` outside `GLDevice`.