### PR TITLE
refactor(renderer): trim RenderContext dead quad/shader resources (RC5 cleanup)

### DIFF
--- a/src/esengine/renderer/RenderContext.cpp
+++ b/src/esengine/renderer/RenderContext.cpp
@@ -11,8 +11,6 @@
 
 #include "RenderContext.hpp"
 #include "GfxDevice.hpp"
-#include "ShaderEmbeds.generated.hpp"
-#include "../resource/ShaderParser.hpp"
 #include "../core/Log.hpp"
 
 namespace esengine {
@@ -34,8 +32,6 @@ void RenderContext::init() {
     }
 
     device_.init();
-    initQuadData();
-    initShaders();
     initWhiteTexture();
 
     initialized_ = true;
@@ -51,65 +47,9 @@ void RenderContext::shutdown() {
         whiteTextureId_ = 0;
     }
 
-    quadVAO_.reset();
-    colorShader_.reset();
-    textureShader_.reset();
-    extMeshShader_.reset();
-
     device_.shutdown();
     initialized_ = false;
     ES_LOG_INFO("RenderContext shutdown");
-}
-
-void RenderContext::initQuadData() {
-    float vertices[] = {
-        -0.5f, -0.5f,       0.0f, 0.0f,
-         0.5f, -0.5f,       1.0f, 0.0f,
-         0.5f,  0.5f,       1.0f, 1.0f,
-        -0.5f,  0.5f,       0.0f, 1.0f
-    };
-
-    u16 indices[] = { 0, 1, 2, 2, 3, 0 };
-
-    quadVAO_ = VertexArray::create(device_);
-
-    auto vbo = VertexBuffer::createRaw(device_, vertices, sizeof(vertices));
-    vbo->setLayout({
-        { ShaderDataType::Float2, "a_position" },
-        { ShaderDataType::Float2, "a_texCoord" }
-    });
-
-    auto ibo = IndexBuffer::create(device_, indices, 6);
-
-    quadVAO_->addVertexBuffer(Shared<VertexBuffer>(std::move(vbo)));
-    quadVAO_->setIndexBuffer(Shared<IndexBuffer>(std::move(ibo)));
-
-    ES_LOG_DEBUG("Quad VAO initialized");
-}
-
-void RenderContext::initShaders() {
-    auto colorParsed = resource::ShaderParser::parse(ShaderEmbeds::COLOR);
-    colorShader_ = Shader::create(
-        device_,
-        resource::ShaderParser::assembleStage(colorParsed, resource::ShaderStage::Vertex),
-        resource::ShaderParser::assembleStage(colorParsed, resource::ShaderStage::Fragment)
-    );
-
-    auto spriteParsed = resource::ShaderParser::parse(ShaderEmbeds::SPRITE);
-    textureShader_ = Shader::create(
-        device_,
-        resource::ShaderParser::assembleStage(spriteParsed, resource::ShaderStage::Vertex),
-        resource::ShaderParser::assembleStage(spriteParsed, resource::ShaderStage::Fragment)
-    );
-
-    extMeshShader_ = Shader::createWithBindings(
-        device_,
-        ShaderSources::EXT_MESH_VERTEX,
-        ShaderSources::EXT_MESH_FRAGMENT,
-        {{0, "a_position"}, {1, "a_texCoord"}, {2, "a_color"}}
-    );
-
-    ES_LOG_DEBUG("Shaders initialized");
 }
 
 void RenderContext::initWhiteTexture() {

--- a/src/esengine/renderer/RenderContext.hpp
+++ b/src/esengine/renderer/RenderContext.hpp
@@ -133,43 +133,17 @@ public:
     // =========================================================================
 
     /**
-     * @brief Gets the quad vertex array
-     * @return Pointer to the quad VAO
-     */
-    VertexArray* getQuadVAO() { return quadVAO_.get(); }
-
-    /**
-     * @brief Gets the color shader
-     * @return Pointer to the color shader
-     */
-    Shader* getColorShader() { return colorShader_.get(); }
-
-    /**
-     * @brief Gets the texture shader
-     * @return Pointer to the texture shader
-     */
-    Shader* getTextureShader() { return textureShader_.get(); }
-
-    Shader* getExtMeshShader() { return extMeshShader_.get(); }
-
-    /**
      * @brief Gets the white texture ID (for untextured quads)
      * @return GPU texture handle
      */
     u32 getWhiteTextureId() const { return whiteTextureId_; }
 
 private:
-    void initQuadData();
-    void initShaders();
     void initWhiteTexture();
 
     glm::mat4 viewProjection_{1.0f};
     RenderContextStats stats_;
 
-    Unique<VertexArray> quadVAO_;
-    Unique<Shader> colorShader_;
-    Unique<Shader> textureShader_;
-    Unique<Shader> extMeshShader_;
     u32 whiteTextureId_ = 0;
 
     GfxDevice& device_;


### PR DESCRIPTION
## What

Dead-code cleanup following the legacy-renderer retirement (#45). The quad VAO and color/texture/extMesh shaders `RenderContext` created were only ever used by the retired `Renderer` class — `getQuadVAO`/`getColorShader`/`getTextureShader`/`getExtMeshShader` now have zero callers.

- Remove those four members, their getters, and `initQuadData`/`initShaders`.
- `RenderContext::init()` now creates only the white texture (its sole live resource), dropping three unused shader compilations + a VAO/VBO/IBO allocation from every App's startup.

Net −86 lines. Verified: no remaining references to the removed symbols.

## Remaining RC5 (optional refinements — assessed)

- **bind() through StateTracker**: a few per-frame `Shader::bind()` sites (PostProcess, ShapePlugin, GeometryBindings, RenderFrame) still route through the device rather than the tracker. This is cache-coherence purity, not a live bug — `StateTracker::reset()` each frame sets the cache to 0 and the main path runs before PostProcess, so no wrong dedup occurs. Completing it means injecting StateTracker into PostProcess.
- **TilemapRenderPlugin dirty**: `collect()` clears `ChunkData.dirty` (a `mutable` content-side flag). The clean fix is a generation counter in `ChunkData` (TilemapSystem change) so the plugin detects rebuilds read-only — orthogonal to the renderer/GfxDevice work.